### PR TITLE
Integrate react-a11y, but don't test against it yet

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,9 @@ var plumber = require('gulp-plumber');
 
 require('node-jsx').install();
 
+if ('ENABLE_REACT_A11Y' in process.env)
+  require('react-a11y')();
+
 var IndexFileStream = require('./lib/gulp-index-file-stream');
 var webpackConfig = require('./webpack.config');
 

--- a/lib/footer.jsx
+++ b/lib/footer.jsx
@@ -103,18 +103,18 @@ var Footer = React.createClass({
         <div className="content col-md-9">
           <div className="row logos">
             <div className="col-sm-4">
-              <a href=""><img src="/img/hive-logo.png"/></a>
+              <a href=""><img src="/img/hive-logo.png" alt="Hive logo"/></a>
 
               <p>Join a Hive Learning Network</p>
               <HiveCities/>
             </div>
             <div className="col-sm-4">
-              <a href=""><img src="/img/mozilla_wordmark.png"/></a>
+              <a href=""><img src="/img/mozilla_wordmark.png" alt="Mozilla wordmark"/></a>
 
               <p>Mozilla radically empowers individuals with skills they need to make the Web.</p>
             </div>
             <div className="col-sm-4">
-              <a href=""><img className="maker-party" src="/img/maker-party-logo.png"/></a>
+              <a href=""><img className="maker-party" src="/img/maker-party-logo.png" alt="Maker Party logo"/></a>
 
               <p>In 2014, nearly 130,000 people in 450 cities around the world helped teach the Web at Maker Parties. Find one near you or start your own.</p>
             </div>

--- a/lib/footer.jsx
+++ b/lib/footer.jsx
@@ -50,7 +50,7 @@ var HiveCities = React.createClass({
           {cities.map(function(city, i) {
             return (
               <li key={i}>
-                <a href="#" className={city.className}>
+                <a href="" className={city.className}>
                   {city.name}
                 </a>
               </li>
@@ -84,18 +84,18 @@ var Footer = React.createClass({
           <div className="row">
             <div className="col-xs-6">
               <ul className="list-unstyled">
-                <li><a href="#">Webmaker</a></li>
-                <li><a href="#">Donate</a></li>
-                <li><a href="#">Legal</a></li>
-                <li><a href="#">Privacy</a></li>
+                <li><a href="">Webmaker</a></li>
+                <li><a href="">Donate</a></li>
+                <li><a href="">Legal</a></li>
+                <li><a href="">Privacy</a></li>
               </ul>
             </div>
             <div className="col-xs-6">
               <ul className="list-unstyled">
-                <li><a href="#">Contact</a></li>
-                <li><a href="#">Twitter</a></li>
-                <li><a href="#">Facebook</a></li>
-                <li><a href="#">Partners</a></li>
+                <li><a href="">Contact</a></li>
+                <li><a href="">Twitter</a></li>
+                <li><a href="">Facebook</a></li>
+                <li><a href="">Partners</a></li>
               </ul>
             </div>
           </div>
@@ -103,18 +103,18 @@ var Footer = React.createClass({
         <div className="content col-md-9">
           <div className="row logos">
             <div className="col-sm-4">
-              <a href="#"><img src="/img/hive-logo.png"/></a>
+              <a href=""><img src="/img/hive-logo.png"/></a>
 
               <p>Join a Hive Learning Network</p>
               <HiveCities/>
             </div>
             <div className="col-sm-4">
-              <a href="#"><img src="/img/mozilla_wordmark.png"/></a>
+              <a href=""><img src="/img/mozilla_wordmark.png"/></a>
 
               <p>Mozilla radically empowers individuals with skills they need to make the Web.</p>
             </div>
             <div className="col-sm-4">
-              <a href="#"><img className="maker-party" src="/img/maker-party-logo.png"/></a>
+              <a href=""><img className="maker-party" src="/img/maker-party-logo.png"/></a>
 
               <p>In 2014, nearly 130,000 people in 450 cities around the world helped teach the Web at Maker Parties. Find one near you or start your own.</p>
             </div>

--- a/lib/homepage.jsx
+++ b/lib/homepage.jsx
@@ -13,7 +13,7 @@ var CaseStudy = React.createClass({
       <div className="col-sm-4 col-sm-offset-1 case-study">
         <img className="img-scale-to-fit" src={study.img}/>
         <h2>{study.name}</h2>
-        <p>{study.description} <a href="#" className="bold-link">Read More</a></p>
+        <p>{study.description} <a href="" className="bold-link">Read More</a></p>
       </div>
     );
   }
@@ -45,7 +45,7 @@ var CaseStudies = React.createClass({
           <CaseStudy study={this.CASE_STUDIES[1]}/>
         </div>
         <div className="become-a-mentor">
-          <a href="#" className="btn btn-awsm">Become A Mentor</a>
+          <a href="" className="btn btn-awsm">Become A Mentor</a>
         </div>
       </div>
     );
@@ -60,7 +60,7 @@ var Values = React.createClass({
           <img src="/img/values.jpg" className="img-circle img-scale-to-fit"/>
         </div>
         <div className="col-sm-6">
-           Join our community of educators, parents, techies and makers who want to teach digital skills and web literacy through making. <a href="#" className="bold-link">Learn More</a>
+           Join our community of educators, parents, techies and makers who want to teach digital skills and web literacy through making. <a href="" className="bold-link">Learn More</a>
         </div>
       </div>
     );

--- a/lib/homepage.jsx
+++ b/lib/homepage.jsx
@@ -11,7 +11,8 @@ var CaseStudy = React.createClass({
 
     return (
       <div className="col-sm-4 col-sm-offset-1 case-study">
-        <img className="img-scale-to-fit" src={study.img}/>
+        <img className="img-scale-to-fit" src={study.img}
+             alt={study.alt}/>
         <h2>{study.name}</h2>
         <p>{study.description} <a href="" className="bold-link">Read More</a></p>
       </div>
@@ -24,11 +25,13 @@ var CaseStudies = React.createClass({
     {
       name: "Sadia's story",
       img: "/img/sadia.jpg",
+      alt: "Photo of Sadia",
       description: "This is a story about how a young girl started a Webmaker club at her school in Bangladesh in order to teach other kids how to code."
     },
     {
       name: "Masud's story",
       img: "/img/masud.jpg",
+      alt: "Photo of Masud",
       description: "This is a story about how a young man got certification through our program and was able to find a job to support his family."
     }
   ],
@@ -57,7 +60,8 @@ var Values = React.createClass({
     return (
       <div className="values row">
         <div className="col-sm-4 col-sm-offset-1">
-          <img src="/img/values.jpg" className="img-circle img-scale-to-fit"/>
+          <img src="/img/values.jpg" className="img-circle img-scale-to-fit"
+               alt="Image reflecting our values"/>
         </div>
         <div className="col-sm-6">
            Join our community of educators, parents, techies and makers who want to teach digital skills and web literacy through making. <a href="" className="bold-link">Learn More</a>

--- a/lib/sidebar.jsx
+++ b/lib/sidebar.jsx
@@ -64,13 +64,13 @@ var Sidebar = React.createClass({
                         ? "collapsible-content"
                         : "hidden-xs hidden-sm collapsible-content"}>
           <div className="sidebar-login">
-            <a href="#">Create an account</a> | <a href="#">Log in</a>
+            <a href="">Create an account</a> | <a href="">Log in</a>
           </div>
           <ul className="sidebar-menu list-unstyled">
             {this.MENU_ENTRIES.map(function(entry, i) {
               return (
                 <li key={i}>
-                  <a href="#">
+                  <a href="">
                     <strong>{entry.name}</strong>
                     <div className="help-text hidden-xs hidden-sm">{entry.help}</div>
                     <span className="glyphicon glyphicon-menu-right"></span>

--- a/lib/sidebar.jsx
+++ b/lib/sidebar.jsx
@@ -55,7 +55,7 @@ var Sidebar = React.createClass({
     return (
       <div className="sidebar col-md-3">
         <div className="sidebar-header">
-          <img src="/img/wm-logo.png"/> Mozilla Learning
+          <img src="/img/wm-logo.png" alt="Webmaker logo"/> Mozilla Learning
           <span className="glyphicon glyphicon-menu-hamburger hidden-lg hidden-md"
                 onClick={this.handleHamburgerClick}/>
           <TriangleCorner className="hidden-xs hidden-sm" height={40}/>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "node-jsx": "^0.12.4",
     "path-posix": "^1.0.0",
     "react": "^0.12.2",
+    "react-a11y": "0.0.6",
     "react-router": "^0.12.4",
     "underscore": "^1.8.2",
     "vinyl": "^0.4.6",


### PR DESCRIPTION
Ok, this is another attempt at #128, with a few changes:

* It's based on the codebase post-#132.
* It doesn't *force* `react-a11y` warnings on ... yet. Since fixing some of them is non-trivial, I just want to merge this PR ASAP to lay the groundwork for solid accessibility support. We can file individual bugs for the existing warnings (they're all the checkboxes in the description for #128), and once those are all resolved, then we can have travis/gulp always test against `react-a11y`.

So, for now, in order to enable the accessibility warnings, you have to put `ENABLE_REACT_A11Y` in your OS environment (it doesn't matter what it's set to, it just has to be in the environment). Then running `gulp test-react-warnings` (or `npm test`) should raise any relevant accessibility issues.

This PR supersedes #128.
