### PR TITLE
Support multiple sidebar colours w/ transition effect (second attempt)

### DIFF
--- a/less/styles.less
+++ b/less/styles.less
@@ -5,6 +5,7 @@
 @screen-teensy: 480px;
 
 @sidebarColor: #d54361;
+@blueSidebarColor: #1F93D0;
 @footerBackgroundColor: #f1f1f1;
 
 body {
@@ -83,8 +84,27 @@ html.no-js .sidebar {
   }
 }
 
+@sidebarTransitionTime: 0.5s;
+
+.page.teaching-materials .sidebar {
+  background-color: @blueSidebarColor;
+
+  .sidebar-header .corner {
+    fill: @blueSidebarColor;
+  }
+
+  .sidebar-menu a:hover, .sidebar-menu a:focus {
+    background-color: darken(@blueSidebarColor, 10%);
+  }
+
+  .sidebar-menu a .glyphicon {
+    color: lighten(@blueSidebarColor, 15%);
+  }
+}
+
 .sidebar {
   background-color: @sidebarColor;
+  transition: background-color @sidebarTransitionTime;
   color: white;
 
   a {
@@ -111,6 +131,7 @@ html.no-js .sidebar {
     right: -1px;
 
     fill: @sidebarColor;
+    transition: fill @sidebarTransitionTime;
   }
 
   .sidebar-header .glyphicon-menu-hamburger {
@@ -135,6 +156,7 @@ html.no-js .sidebar {
   .sidebar-menu a:hover, .sidebar-menu a:focus {
     text-decoration: none;
     background-color: darken(@sidebarColor, 10%);
+    transition: background-color @sidebarTransitionTime;
   }
 
   .sidebar-menu a strong {
@@ -155,6 +177,7 @@ html.no-js .sidebar {
     font-size: 15px;
     top: calc(50% - 15px / 2);
     color: lighten(@sidebarColor, 15%);
+    transition: color @sidebarTransitionTime;
   }
 }
 

--- a/lib/page.jsx
+++ b/lib/page.jsx
@@ -6,9 +6,11 @@ var Sidebar = require('./sidebar.jsx');
 var Footer = require('./footer.jsx');
 
 var Page = React.createClass({
+  mixins: [Router.State],
   render: function() {
+    var pageClassName = this.getRoutes()[1].handler.pageClassName || '';
     return (
-      <div className="page container-fluid">
+      <div className={"page container-fluid " + pageClassName}>
         <div className="row">
           <Sidebar/>
           <div className="content col-md-9">

--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -9,6 +9,9 @@ var HeroUnit = require('./hero-unit.jsx');
 var Homepage = require('./homepage.jsx');
 
 var Foo = React.createClass({
+  statics: {
+    pageClassName: 'teaching-materials'
+  },
   render: function() {
     return (
       <div>


### PR DESCRIPTION
This is a second attempt at addding support for multiple sidebar colors (the first was #111).

If the user's browser supports `pushState`, we don't actually need to unload the page, and can therefore take advantage of CSS transitions, as shown in this video:

<a href="https://toolness-media.herokuapp.com/v/mozilla-learning-sidebar-transition/play/loop"><img src="https://toolness-media.herokuapp.com/v/mozilla-learning-sidebar-transition.poster.play.jpg?bust2" alt="Play 'Mozilla Learning Sidebar Transition' video"></a>