### PR TITLE
Add mocha tests for server/site-generator and browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 [![Build Status](https://travis-ci.org/mozilla/teach.webmaker.org.svg)](https://travis-ci.org/mozilla/teach.webmaker.org)
 
 This is an initial attempt at implementing the Webmaker Learning
-front-page.
+website.
+
+# Overview
+
+This software consists of two major parts:
+
+* A **static site generator** that creates a number of
+  `index.html` files in various directories which can be viewed
+  in any browser, including ones that don't support JavaScript.
+* Client-side JavaScript code that **progressively enhances**
+  the user experience based on browser capabilities.
+
+It should be noted that, based on the
+[product roadmap][roadmap], the static site generator
+may eventually evolve into becoming a dynamic server.
 
 # Get started
 
@@ -30,6 +44,43 @@ npm start
 ```
 
 This will start a webserver for you at `http://localhost:8008`, and run a `watch` process so that your front-end assets will be regenerated as you make changes.
+
+### Test
+
+Testing the code is accomplished by running `npm test`,
+which exercises a number of different aspects of the
+codebase described below.
+
+#### Static Site Generation (Smoke Test)
+
+`npm test` always generates a full static site and
+ensures that **no React warnings are raised**.
+[react-a11y][] is used to ensure that no accessibility
+issues are present.
+
+#### Unit Tests
+
+Unit tests are spread across two different testing
+environments.
+
+Both environments the [mocha][] test runner and [should][]
+for assertions.
+
+##### Node Tests
+
+These tests generally exercise the code of the static site generator
+and are located in the `test` directory.
+
+Each test file should end with `.test.js` and will be automatically
+discovered by the test suite.
+
+##### Browser Tests
+
+These tests exercise the code that runs in user's browser. They're
+located in the `test/browser` directory.
+
+Browser test files are *not* automatically discovered and should
+be explicitly `require`'d in `test/browser/main.js`.
 
 ## Generating A Static Site
 
@@ -71,5 +122,6 @@ string), the boolean is true; otherwise, it's false.
   [`devtool`]: http://webpack.github.io/docs/configuration.html#devtool
   [sourcemaps-wtf]: https://github.com/mozilla/teach.webmaker.org/pull/147#discussion-diff-25879885
   [react-a11y]: https://github.com/rackt/react-a11y#readme
-  [#138]: https://github.com/mozilla/teach.webmaker.org/issues/138
-
+  [roadmap]: https://wiki.mozilla.org/Learning/Networks/Product-Roadmap
+  [mocha]: http://mochajs.org/
+  [should]: https://www.npmjs.com/package/should

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var less = require('gulp-less');
 var prettify = require('gulp-prettify');
 var webpack = require('gulp-webpack');
 var plumber = require('gulp-plumber');
+var merge = require('merge-stream');
 
 require('node-jsx').install();
 
@@ -19,6 +20,7 @@ var IndexFileStream = require('./lib/gulp-index-file-stream');
 var webpackConfig = require('./webpack.config');
 
 var BUILD_TASKS = [
+  'copy-test-dirs',
   'copy-dirs',
   'less',
   'webpack',
@@ -45,6 +47,17 @@ function handleError() {
   });
 }
 
+gulp.task('copy-test-dirs', function() {
+  return merge(
+    gulp.src('test/browser/static/**', {
+      base: './test/browser/static'
+    }),
+    gulp.src('node_modules/mocha/mocha.*', {
+      base: './node_modules/mocha'
+    })
+  ).pipe(gulp.dest('./dist/test'));
+});
+
 gulp.task('copy-dirs', function() {
   return gulp.src(COPY_DIRS, {
     base: '.'
@@ -61,7 +74,7 @@ gulp.task('less', function() {
 });
 
 gulp.task('webpack', function() {
-  return gulp.src(webpackConfig.entry)
+  return gulp.src(webpackConfig.entry.app)
     .pipe(webpack(webpackConfig))
     .pipe(gulp.dest('./dist'));
 });
@@ -102,7 +115,7 @@ gulp.task('default', BUILD_TASKS);
 gulp.task ('dev', ['watch', 'server']);
 
 gulp.task('watch', _.without(BUILD_TASKS, 'webpack'), function(cb) {
-  gulp.src(webpackConfig.entry)
+  gulp.src(webpackConfig.entry.app)
     .pipe(webpack(_.extend({
       watch: true
     }, webpackConfig)))
@@ -133,6 +146,7 @@ gulp.task('watch', _.without(BUILD_TASKS, 'webpack'), function(cb) {
 
   gulp.watch(COPY_DIRS, ['copy-dirs']);
   gulp.watch(LESS_FILES, ['less']);
+  gulp.watch('test/browser/static/**', ['copy-test-dirs']);
 });
 
 gulp.task('server', function () {

--- a/lib/index-static.jsx
+++ b/lib/index-static.jsx
@@ -24,7 +24,8 @@ function generateWithPageHTML(url, options, pageHTML) {
         <div id="page-holder" dangerouslySetInnerHTML={{
           __html: pageHTML
         }}></div>
-        <script src={'/' + exports.JS_FILENAME}></script>
+        <script src="/commons.bundle.js"></script>
+        <script src="/app.bundle.js"></script>
       </body>
     </html>
   );
@@ -40,5 +41,4 @@ function generate(url, options, cb) {
 
 exports.generate = generate;
 exports.CSS_FILENAME = "styles.css";
-exports.JS_FILENAME = "bundle.js";
 exports.URLS = routes.URLS;

--- a/package.json
+++ b/package.json
@@ -13,18 +13,21 @@
     "gulp-webpack": "^1.2.0",
     "gulp-webserver": "^0.9.0",
     "jsx-loader": "^0.12.2",
+    "merge-stream": "^0.1.7",
+    "mocha": "^2.1.0",
     "node-jsx": "^0.12.4",
     "path-posix": "^1.0.0",
     "react": "^0.12.2",
     "react-a11y": "0.0.6",
     "react-router": "^0.12.4",
+    "should": "^5.1.0",
     "underscore": "^1.8.2",
     "vinyl": "^0.4.6",
     "webpack": "^1.6.0"
   },
   "devDependencies": {},
   "scripts": {
-    "test": "gulp test",
+    "test": "gulp test && mocha test/*.test.js",
     "build": "gulp",
     "start": "gulp dev",
     "watch": "gulp watch"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "jsx-loader": "^0.12.2",
     "merge-stream": "^0.1.7",
     "mocha": "^2.1.0",
+    "mocha-phantomjs": "^3.5.3",
     "node-jsx": "^0.12.4",
     "path-posix": "^1.0.0",
+    "phantomjs": "^1.9.16",
     "react": "^0.12.2",
     "react-a11y": "0.0.6",
     "react-router": "^0.12.4",
@@ -28,7 +30,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "gulp test && mocha test/*.test.js",
+    "test": "gulp test && mocha test/*.test.js && mocha-phantomjs dist/test/index.html",
     "build": "gulp",
     "start": "gulp watch"
   },

--- a/test/browser/config.test.js
+++ b/test/browser/config.test.js
@@ -1,0 +1,10 @@
+var should = require('should');
+
+var config = require('../../lib/config');
+
+describe("config", function() {
+  it('should think it is in the browser', function() {
+    config.IN_STATIC_SITE.should.be.true;
+    config.GENERATING_STATIC_SITE.should.be.false;
+  });
+});

--- a/test/browser/main.js
+++ b/test/browser/main.js
@@ -1,0 +1,1 @@
+require('./config.test.js');

--- a/test/browser/static/index.html
+++ b/test/browser/static/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="stylesheet" href="mocha.css">
+<title>Tests</title>
+<div id="mocha"></div>
+<script src="mocha.js"></script>
+<script>
+mocha.setup('bdd');
+</script>
+<script src="/commons.bundle.js"></script>
+<script src="/tests.bundle.js"></script>
+<script>
+mocha.run();
+</script>

--- a/test/browser/static/index.html
+++ b/test/browser/static/index.html
@@ -7,8 +7,12 @@
 <script>
 mocha.setup('bdd');
 </script>
-<script src="/commons.bundle.js"></script>
-<script src="/tests.bundle.js"></script>
+<script src="../commons.bundle.js"></script>
+<script src="../tests.bundle.js"></script>
 <script>
-mocha.run();
+if (window.mochaPhantomJS) {
+  mochaPhantomJS.run();
+} else {
+  mocha.run();
+}
 </script>

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,10 @@
+var should = require('should');
+
+var config = require('../lib/config');
+
+describe("config", function() {
+  it('should think it is not in the browser', function() {
+    config.IN_STATIC_SITE.should.be.false;
+    config.GENERATING_STATIC_SITE.should.be.true;
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,18 +1,21 @@
 var webpack = require('webpack');
 
-require('node-jsx').install();
-
-var index = require('./lib/index-static.jsx');
-
 module.exports = {
-  entry: './lib/main.jsx',
+  entry: {
+    app: './lib/main.jsx',
+    tests: './test/browser/main.js'
+  },
   output: {
     path: __dirname + '/dist',
-    filename: index.JS_FILENAME
+    filename: '[name].bundle.js'
   },
   module: {
     loaders: [
       {test: /\.jsx$/, loader: "jsx-loader"}
     ]
-  }
+  },
+  plugins: [
+    new webpack.optimize.CommonsChunkPlugin('commons',
+                                            'commons.bundle.js')
+  ]
 };


### PR DESCRIPTION
This attempts to resolve a lot of #112 by adding simple [mocha](http://mochajs.org/)-based test frameworks for:

* **The static site generator.** This is our version of the "server", the program that runs on a build machine to generate the static website. These tests are located in the `test` directory.
* **The browser.** This is the code that runs in user's browsers to progressively enhance their experience. These tests are located in the `test/browser` directory.

Currently there's only trivial test suites for [`lib/config.js`](https://github.com/mozilla/teach.webmaker.org/blob/master/lib/config.js), which behaves differently in the two environments.

In both environments, [`should`](https://www.npmjs.com/package/should) is used for test assertions. This assertion library only works on IE9+, but that should be OK for us; I'm assuming at the moment that we'll essentially not progressively enhance anything below IE9, thus leaving nothing to test on the browser.

This PR also introduces Webpack's [code splitting](http://webpack.github.io/docs/code-splitting.html) functionality to make builds faster and ensure that the browser-side tests use the exact same code as the app.

Tasks left to do:
- [X] Formally decide what browsers to support on the client-side and document it. If we *are* supporting client-side JS on browsers below IE9, we should switch from `should` to something else like [`expect`](https://github.com/Automattic/expect.js). **This decision has been moved to #151.**
- [x] Document the testing system and process of adding new tests to `README.md`.
- [x] Use [`mocha-phantomjs`](https://github.com/metaskills/mocha-phantomjs) to run the browser tests from the command-line, and as part of the Travis CI build.
