### PR TITLE
Coalesce the 'watch' and 'server' tasks, fixing #145.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,8 +99,6 @@ gulp.task('generate-index-files', function() {
 
 gulp.task('default', BUILD_TASKS);
 
-gulp.task ('dev', ['watch', 'server']);
-
 gulp.task('watch', _.without(BUILD_TASKS, 'webpack'), function(cb) {
   gulp.src(webpackConfig.entry)
     .pipe(webpack(_.extend({
@@ -133,10 +131,8 @@ gulp.task('watch', _.without(BUILD_TASKS, 'webpack'), function(cb) {
 
   gulp.watch(COPY_DIRS, ['copy-dirs']);
   gulp.watch(LESS_FILES, ['less']);
-});
 
-gulp.task('server', function () {
-  return gulp.src('dist')
+  gulp.src('dist')
     .pipe(webserver({
       livereload: {
         enable: true

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   "scripts": {
     "test": "gulp test",
     "build": "gulp",
-    "start": "gulp dev",
-    "watch": "gulp watch"
+    "start": "gulp watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
If a compelling use case for running `watch` without `server` (or vice versa) arises, we can always bring back the functionality too, so long as we don't regress back to #145 when we do.

@alicoding can you review this?