### PR TITLE
Add JS and CSS sourcemaps.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var less = require('gulp-less');
 var prettify = require('gulp-prettify');
 var webpack = require('gulp-webpack');
 var plumber = require('gulp-plumber');
+var sourcemaps = require('gulp-sourcemaps');
 
 require('node-jsx').install();
 
@@ -54,9 +55,11 @@ gulp.task('copy-dirs', function() {
 gulp.task('less', function() {
   return gulp.src(LESS_FILES)
     .pipe(handleError())
+    .pipe(sourcemaps.init())
     .pipe(less({
       paths: [path.join(__dirname, 'less')]
     }))
+    .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest('./dist'));
 });
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "gulp-plumber": "^0.6.6",
     "gulp-prettify": "^0.3.0",
     "gulp-s3": "^0.3.0",
+    "gulp-sourcemaps": "^1.5.0",
     "gulp-util": "^3.0.4",
     "gulp-webpack": "^1.2.0",
     "gulp-webserver": "^0.9.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ var index = require('./lib/index-static.jsx');
 
 module.exports = {
   entry: './lib/main.jsx',
+  devtool: 'source-map',
   output: {
     path: __dirname + '/dist',
     filename: index.JS_FILENAME


### PR DESCRIPTION
As mentioned in https://github.com/mozilla/teach.webmaker.org/pull/139#issuecomment-77400812, this adds JS and CSS source maps to *all builds*, regardless of whether they're dev or prod.

Since the source maps are provided in separate `.map.` files that only dev tools access, they shouldn't impact the load times of production builds, and they also encourage anyone to delve into our site and see how it works!
