### PR TITLE
Add some placeholder pages

### DIFF
--- a/lib/homepage.jsx
+++ b/lib/homepage.jsx
@@ -77,7 +77,7 @@ var Homepage = React.createClass({
       <div>
         <HeroUnit image="/img/hero-unit.jpg">
           <h1>Unlock opportunities for all citizens of the Web.</h1>
-          <div><Link to="/foo/" className="btn btn-awsm">Join Us</Link></div>
+          <div><Link to="/join/" className="btn btn-awsm">Join Us</Link></div>
         </HeroUnit>
         <Values/>
         <CaseStudies/>

--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -9,26 +9,46 @@ var HeroUnit = require('./hero-unit.jsx');
 var Homepage = require('./homepage.jsx');
 var urls = [];
 
-var Foo = React.createClass({
-  statics: {
-    pageClassName: 'teaching-materials'
-  },
-  render: function() {
-    return (
-      <div>
-        <HeroUnit image="http://placekitten.com/g/1024/480">
-          <h1>I am foo.</h1>
-          <div><Link to="/" className="btn btn-awsm">Meow</Link></div>
-        </HeroUnit>
-        <h2>Content can go here.</h2>
-      </div>
-    );
-  }
-});
+function placeholderPage(options) {
+  return React.createClass({
+    statics: {
+      pageClassName: options.pageClassName
+    },
+    render: function() {
+      return (
+        <div>
+          <HeroUnit image="/img/hero-unit.jpg">
+            <h1>Placeholder: {options.title}</h1>
+          </HeroUnit>
+          <h2>This is a placeholder page for &ldquo;{options.title}&rdquo;.</h2>
+          {options.githubIssue
+           ? <p>Discussion about this page can be found on GitHub at <a
+               href={"https://github.com/mozilla/teach.webmaker.org/issues/" +
+                     options.githubIssue}>
+                 <code style={{
+                   color: '#1F93D0',
+                   backgroundColor: '#f0f0f0'
+                 }}>mozilla/teach.webmaker.org#{options.githubIssue}</code>
+               </a>.
+             </p>
+           : null}
+        </div>
+      );
+    }
+  })
+}
 
 var routes = (
   <Route handler={Page}>
-    <Route name="/foo/" handler={Foo}/>
+    <Route name="/join/" handler={placeholderPage({
+      title: 'Join Us',
+      githubIssue: 154
+    })}/>
+    <Route name="/activities/" handler={placeholderPage({
+      title: 'Teaching Activities',
+      pageClassName: 'teaching-materials',
+      githubIssue: 36
+    })}/>
     <DefaultRoute name="/" handler={Homepage}/>
   </Route>
 );

--- a/lib/sidebar.jsx
+++ b/lib/sidebar.jsx
@@ -1,4 +1,6 @@
 var React = require('react');
+var Router = require('react-router');
+var Link = Router.Link;
 
 var TriangleCorner = React.createClass({
   propTypes: {
@@ -26,6 +28,7 @@ var Sidebar = React.createClass({
   MENU_ENTRIES: [
     {
       name: "Teaching Materials",
+      link: '/activities/',
       help: "Activities and lesson plans to get you started"
     },
     {
@@ -70,11 +73,11 @@ var Sidebar = React.createClass({
             {this.MENU_ENTRIES.map(function(entry, i) {
               return (
                 <li key={i}>
-                  <a href="">
+                  <Link to={entry.link || '/'}>
                     <strong>{entry.name}</strong>
                     <div className="help-text hidden-xs hidden-sm">{entry.help}</div>
                     <span className="glyphicon glyphicon-menu-right"></span>
-                  </a>
+                  </Link>
                 </li>
               );
             })}

--- a/test/browser/sidebar.test.jsx
+++ b/test/browser/sidebar.test.jsx
@@ -2,13 +2,14 @@ var should = require('should');
 var React =require('react/addons');
 var TestUtils = React.addons.TestUtils;
 
+var stubRouterContext = require('./stub-router-context.jsx');
 var Sidebar = require('../../lib/sidebar.jsx');
 
 describe("sidebar", function() {
   var sidebar, hamburger, collapsibleContent;
 
   beforeEach(function() {
-    sidebar = TestUtils.renderIntoDocument(<Sidebar/>);
+    sidebar = stubRouterContext.render(Sidebar, {});
     hamburger = TestUtils.findRenderedDOMComponentWithClass(
       sidebar,
       'glyphicon-menu-hamburger'

--- a/test/browser/stub-router-context.jsx
+++ b/test/browser/stub-router-context.jsx
@@ -1,0 +1,53 @@
+// https://github.com/rackt/react-router/blob/master/docs/guides/testing.md
+
+var _ = require('underscore');
+var React =require('react/addons');
+var TestUtils = React.addons.TestUtils;
+
+var stubRouterContext = function(Component, props, stubs) {
+  var func = React.PropTypes.func;
+  var noop = function() {};
+
+  return React.createClass({
+    childContextTypes: {
+      makePath: func,
+      makeHref: func,
+      transitionTo: func,
+      replaceWith: func,
+      goBack: func,
+      getCurrentPath: func,
+      getCurrentRoutes: func,
+      getCurrentPathname: func,
+      getCurrentParams: func,
+      getCurrentQuery: func,
+      isActive: func,
+    },
+
+    getChildContext: function() {
+      return _.extend({
+        makePath: noop,
+        makeHref: noop,
+        transitionTo: noop,
+        replaceWith: noop,
+        goBack: noop,
+        getCurrentPath: noop,
+        getCurrentRoutes: noop,
+        getCurrentPathname: noop,
+        getCurrentParams: noop,
+        getCurrentQuery: noop,
+        isActive: noop
+      }, stubs);
+    },
+
+    render: function() {
+      return <Component {...props} ref="unstubbed" />;
+    }
+  });
+};
+
+stubRouterContext.render = function(Component, props) {
+  var Stubbed = stubRouterContext(Component, props);
+  return TestUtils.renderIntoDocument(<Stubbed/>).refs.unstubbed;
+};
+
+module.exports = stubRouterContext;


### PR DESCRIPTION
This adds a factory function in `routes.jsx` called `placeholderPage` which returns a one-off React component class that represents a placeholder page with a link to the GitHub issue for the page's design discussion.

Because I also added a `<Link>` to the sidebar, it broke the sidebar tests, because of react-router's reliance on the undocumented `context` feature of React. I found a [react-router testing guide](https://github.com/rackt/react-router/blob/master/docs/guides/testing.md) on how to get around this and implemented a fix.

Here's an example of what the placeholder page for "Teaching Activities" looks like:

![2015-03-06_9-27-46](https://cloud.githubusercontent.com/assets/124687/6526742/2655575e-c3e3-11e4-8452-b4c54c6b75ea.jpg)

The code for the above page is in `routes.jsx`:

```jsx
    <Route name="/activities/" handler={placeholderPage({
      title: 'Teaching Activities',
      pageClassName: 'teaching-materials',
      githubIssue: 36
    })}/>
```
