### PR TITLE
Add manual test suite

### DIFF
--- a/test/browser/manual-main.jsx
+++ b/test/browser/manual-main.jsx
@@ -1,0 +1,110 @@
+var React = require('react');
+
+var routes = require('../../lib/routes.jsx');
+
+var RouteThumbnail = React.createClass({
+  ASPECT_RATIO: 3/4,
+  getInitialState: function() {
+    return {
+      scaledWidth: this.props.width
+    };
+  },
+  getScale: function() {
+    return this.state.scaledWidth / this.props.width;
+  },
+  getScaledHeight: function() {
+    return this.getHeight() * this.getScale();
+  },
+  getHeight: function() {
+    return this.props.width * this.ASPECT_RATIO;
+  },
+  handleResize: function() {
+    var selfEl = this.getDOMNode();
+    var rect = selfEl.parentNode.getBoundingClientRect();
+
+    this.setState({
+      scaledWidth: rect.width
+    });
+  },
+  componentDidMount: function() {
+    window.addEventListener('resize', this.handleResize);
+    this.handleResize();
+  },
+  componentWillUnmount: function() {
+    window.removeEventListener('resize', this.handleResize);
+  },
+  render: function() {
+    return (
+      <div>
+        <div style={{
+          transform: 'scale(' + this.getScale() + ')',
+          transformOrigin: 'top left',
+          height: this.getScaledHeight()
+        }}>
+          <iframe src={this.props.url} sandbox="" style={{
+            border: '1px solid black',
+            width: this.props.width,
+            height: this.getHeight()
+          }}></iframe>
+        </div>
+        <h4>{this.props.name} <span className="text-muted">
+          {this.props.width}x{this.getHeight()}
+        </span></h4>
+      </div>
+    );
+  }
+});
+
+var RouteTest = React.createClass({
+  render: function() {
+    return (
+      <div>
+        <h2 className="route">
+          <a href={this.props.url} target="_blank">
+            {this.props.url}
+          </a>
+        </h2>
+        <div className="row">
+          <div className="col-md-4">
+            <RouteThumbnail
+             name="Desktop"
+             width={1024}
+             url={this.props.url}/>
+          </div>
+          <div className="col-md-4">
+            <RouteThumbnail
+             name="Tablet"
+             width={800}
+             url={this.props.url}/>
+          </div>
+          <div className="col-md-4">
+            <RouteThumbnail
+             name="Mobile"
+             width={480}
+             url={this.props.url}/>
+          </div>
+        </div>
+      </div>
+    );
+  }
+});
+
+var ManualTests = React.createClass({
+  render: function() {
+    return (
+      <div className="container">
+        <h1>Manual Tests</h1>
+        <p>Below are thumbnails of all the pages on the site, rendered without JavaScript enabled.</p>
+        <p>Please verify that they all look decent.</p>
+        {this.props.urls.map(function(url) {
+          return <RouteTest key={url} url={url}/>;
+        })}
+      </div>
+    );
+  }
+});
+
+React.render(
+  <ManualTests urls={routes.URLS.slice().sort()}/>,
+  document.getElementById('app')
+);

--- a/test/browser/manual-main.jsx
+++ b/test/browser/manual-main.jsx
@@ -21,10 +21,9 @@ var RouteThumbnail = React.createClass({
   },
   handleResize: function() {
     var selfEl = this.getDOMNode();
-    var rect = selfEl.parentNode.getBoundingClientRect();
 
     this.setState({
-      scaledWidth: rect.width
+      scaledWidth: selfEl.parentNode.clientWidth
     });
   },
   componentDidMount: function() {
@@ -69,25 +68,31 @@ var RouteTest = React.createClass({
         </h2>
         <div className="row">
           <div className="col-md-4">
-            <RouteThumbnail
-             name="Desktop"
-             width={1024}
-             enableJS={this.props.enableJS}
-             url={this.props.url}/>
+            <div>
+              <RouteThumbnail
+               name="Desktop"
+               width={1024}
+               enableJS={this.props.enableJS}
+               url={this.props.url}/>
+            </div>
           </div>
           <div className="col-md-4">
-            <RouteThumbnail
-             name="Tablet"
-             width={800}
-             enableJS={this.props.enableJS}
-             url={this.props.url}/>
+            <div>
+              <RouteThumbnail
+               name="Tablet"
+               width={800}
+               enableJS={this.props.enableJS}
+               url={this.props.url}/>
+            </div>
           </div>
           <div className="col-md-4">
-            <RouteThumbnail
-             name="Mobile"
-             width={480}
-             enableJS={this.props.enableJS}
-             url={this.props.url}/>
+            <div>
+              <RouteThumbnail
+               name="Mobile"
+               width={480}
+               enableJS={this.props.enableJS}
+               url={this.props.url}/>
+            </div>
           </div>
         </div>
       </div>

--- a/test/browser/manual-main.jsx
+++ b/test/browser/manual-main.jsx
@@ -142,6 +142,11 @@ React.render(
      } else {
        qs.enableJS = 'on';
      }
+     // It'd be nice if we didn't have to reload the page here, but
+     // browsers don't like the 'sandbox' attribute of iframes
+     // changing dynamically, and destroying/rebuilding the iframes
+     // manually in react is a pain, so we'll just trigger a page
+     // reload instead.
      location.search = '?' + querystring.stringify(qs);
    }}
    />,

--- a/test/browser/manual-main.jsx
+++ b/test/browser/manual-main.jsx
@@ -1,3 +1,4 @@
+var querystring = require('querystring');
 var React = require('react');
 
 var routes = require('../../lib/routes.jsx');
@@ -40,8 +41,10 @@ var RouteThumbnail = React.createClass({
           transform: 'scale(' + this.getScale() + ')',
           transformOrigin: 'top left',
           height: this.getScaledHeight()
-        }}>
-          <iframe src={this.props.url} sandbox="" style={{
+        }} ref="iframeHolder">
+          <iframe src={this.props.url} sandbox={
+            this.props.enableJS ? null : ""
+          } style={{
             border: '1px solid black',
             width: this.props.width,
             height: this.getHeight()
@@ -69,18 +72,21 @@ var RouteTest = React.createClass({
             <RouteThumbnail
              name="Desktop"
              width={1024}
+             enableJS={this.props.enableJS}
              url={this.props.url}/>
           </div>
           <div className="col-md-4">
             <RouteThumbnail
              name="Tablet"
              width={800}
+             enableJS={this.props.enableJS}
              url={this.props.url}/>
           </div>
           <div className="col-md-4">
             <RouteThumbnail
              name="Mobile"
              width={480}
+             enableJS={this.props.enableJS}
              url={this.props.url}/>
           </div>
         </div>
@@ -92,19 +98,47 @@ var RouteTest = React.createClass({
 var ManualTests = React.createClass({
   render: function() {
     return (
-      <div className="container">
-        <h1>Manual Tests</h1>
-        <p>Below are thumbnails of all the pages on the site, rendered without JavaScript enabled.</p>
-        <p>Please verify that they all look decent.</p>
-        {this.props.urls.map(function(url) {
-          return <RouteTest key={url} url={url}/>;
-        })}
+      <div>
+        <nav className="navbar navbar-default navbar-fixed-top">
+          <div className="container-fluid">
+            <form className="navbar-form navbar-right">
+              <div className="checkbox">
+                <label>
+                  <input type="checkbox" checked={this.props.enableJS} onChange={this.props.onToggleEnableJS}/> Enable JavaScript in thumbnails
+                </label>
+              </div>
+            </form>
+          </div>
+        </nav>
+        <div className="container-fluid">
+          <h1>Manual Tests</h1>
+          <p>Below are thumbnails of all the pages on the site, rendered <strong>{
+            this.props.enableJS ? "with" : "without"
+          }</strong> JavaScript enabled.</p>
+          <p>Please verify that they all look decent.</p>
+          {this.props.urls.map(function(url) {
+            return <RouteTest key={url} url={url} enableJS={this.props.enableJS}/>;
+          }, this)}
+        </div>
       </div>
     );
   }
 });
 
+var qs = querystring.parse(location.search.slice(1));
+
 React.render(
-  <ManualTests urls={routes.URLS.slice().sort()}/>,
+  <ManualTests
+   urls={routes.URLS.slice().sort()}
+   enableJS={qs.enableJS == 'on'}
+   onToggleEnableJS={function() {
+     if (qs.enableJS == 'on') {
+       delete qs.enableJS;
+     } else {
+       qs.enableJS = 'on';
+     }
+     location.search = '?' + querystring.stringify(qs);
+   }}
+   />,
   document.getElementById('app')
 );

--- a/test/browser/manual-main.jsx
+++ b/test/browser/manual-main.jsx
@@ -67,7 +67,7 @@ var RouteTest = React.createClass({
           </a>
         </h2>
         <div className="row">
-          <div className="col-md-4">
+          <div className="col-xs-4">
             <div>
               <RouteThumbnail
                name="Desktop"
@@ -76,7 +76,7 @@ var RouteTest = React.createClass({
                url={this.props.url}/>
             </div>
           </div>
-          <div className="col-md-4">
+          <div className="col-xs-4">
             <div>
               <RouteThumbnail
                name="Tablet"
@@ -85,7 +85,7 @@ var RouteTest = React.createClass({
                url={this.props.url}/>
             </div>
           </div>
-          <div className="col-md-4">
+          <div className="col-xs-4">
             <div>
               <RouteThumbnail
                name="Mobile"

--- a/test/browser/static/index.html
+++ b/test/browser/static/index.html
@@ -1,7 +1,26 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <link rel="stylesheet" href="mocha.css">
+<style>
+.reminder {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 6px;
+  font-family: sans-serif;
+  font-size: 12px;
+  background-color: rgba(0, 0, 0, 0.75);
+  color: white;
+}
+
+.reminder a {
+  color: inherit;
+}
+</style>
 <title>Tests</title>
+<div class="reminder">
+  Please remember to run the <a href="manual/">Manual Tests</a> too!
+</div>
 <div id="mocha"></div>
 <script src="mocha.js"></script>
 <script>

--- a/test/browser/static/manual/index.html
+++ b/test/browser/static/manual/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="stylesheet" href="/vendor/bootstrap/css/bootstrap.css">
+<style>
+body {
+  margin-bottom: 1em;
+}
+
+.route {
+  font-family: monospace;
+  font-size: 3rem;
+}
+
+.route a {
+  color: inherit;
+}
+</style>
+<title>Manual Tests</title>
+<div id="app"></div>
+<script src="/commons.bundle.js"></script>
+<script src="/manualTests.bundle.js"></script>

--- a/test/browser/static/manual/index.html
+++ b/test/browser/static/manual/index.html
@@ -4,6 +4,7 @@
 <style>
 body {
   margin-bottom: 1em;
+  padding-top: 70px;
 }
 
 .route {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ var IMPORT_ES5_SHIM = "imports?shim=es5-shim/es5-shim&" +
 module.exports = {
   entry: {
     app: './lib/main.jsx',
+    manualTests: './test/browser/manual-main.jsx',
     tests: './test/browser/main.js'
   },
   devtool: process.env.WEBPACK_DEVTOOL || 'source-map',


### PR DESCRIPTION
This just adds a page at `/test/manual/` that shows all the static pages of the site in iframes at different sizes, which should make it easier for us to verify that every that everything looks okay. A checkbox is provided to allow the tester to see the thumbnails with JS enabled or disabled (requires a browser with support for the [iframe sandbox attribute](http://caniuse.com/#feat=iframe-sandbox)).

Here's what it looks like right now:

![2015-03-09_10-17-38](https://cloud.githubusercontent.com/assets/124687/6556766/1a11ee66-c646-11e4-923b-b121855f10ef.jpg)

At present all the iframes are loaded at once, but as the site grows we can change the manual test suite to only render iframes that are within the visible viewport.