### PR TITLE
Tell user to re-run 'npm start' if crucial files change.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -160,6 +160,17 @@ gulp.task('watch', _.without(BUILD_TASKS, 'webpack'), function(cb) {
   gulp.watch(COPY_DIRS, ['copy-dirs']);
   gulp.watch(LESS_FILES, ['less']);
   gulp.watch('test/browser/static/**', ['copy-test-dirs']);
+  gulp.watch([
+    'gulpfile.js',
+    'package.json',
+    'webpack.config.js'
+  ], function(event) {
+    var filename = path.basename(event.path);
+    gutil.log(gutil.colors.red.bold(filename + ' was ' + event.type + '.'));
+    gutil.log(gutil.colors.red.bold('Please restart the watch process ' +
+                                    'with "npm start".'));
+    process.exit(0);
+  });
 
   gulp.src('dist')
     .pipe(webserver({


### PR DESCRIPTION
After running "git pull" or changing files like `gulpfile.js`, `package.json`, and `webpack.config.js`, it might not occur to novice (or even expert) developers that they need to re-run `npm start`/`gulp watch`. This simple modification to `gulp watch` just watches those three files: if they ever change, it immediately tells the user to re-run `npm start` and exits.

(Even better would be to auto-restart the process ourselves, but I'm afraid of weird edge cases or bizarre infinite-restart loops and such.)