### PR TITLE
Use webpack's DefinePlugin to transfer whitelisted process.env vars to the browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ string), the boolean is true; otherwise, it's false.
   in situations where absolute URLs are required, such
   as generating a `sitemap.xml` file.
 
+* `MAPBOX_ACCESS_TOKEN` is the [Mapbox][] access token to use for
+  embedded maps in the website. Optional.
+
+* `MAPBOX_MAP_ID` is the Mapbox map ID to use for embedded maps in
+  the website. Optional.
+
 ## References
 
 * [Cassie's original PSD files][psd]
@@ -159,3 +165,4 @@ string), the boolean is true; otherwise, it's false.
   [mocha (1)]: http://mochajs.org/#usage
   [should]: https://www.npmjs.com/package/should
   [teach.mofostaging.net]: http://teach.mofostaging.net/
+  [Mapbox]: http://mapbox.com/

--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -34,8 +34,11 @@ function placeholderPage(options) {
              </p>
            : null}
           {options.pageClassName == 'clubs'
-            ? <SingletonMapComponent accessToken={'pk.eyJ1IjoiYWxpY29kaW5nIiwiYSI6Il90WlNFdE0ifQ.QGGdXGA_2QH-6ujyZE2oSg'}
-                mapId={'alicoding.ldmhe4f3'}/> : null}
+            ? <SingletonMapComponent accessToken={
+                process.env.MAPBOX_ACCESS_TOKEN || 'pk.eyJ1IjoiYWxpY29kaW5nIiwiYSI6Il90WlNFdE0ifQ.QGGdXGA_2QH-6ujyZE2oSg'
+              } mapId={
+                process.env.MAPBOX_MAP_ID || 'alicoding.ldmhe4f3'
+              }/> : null}
         </div>
       );
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,17 @@ var webpack = require('webpack');
 var IMPORT_ES5_SHIM = "imports?shim=es5-shim/es5-shim&" +
                       "sham=es5-shim/es5-sham";
 
+function importEnvVars(keys) {
+  var result = {};
+
+  keys.forEach(function(key) {
+    if (typeof(process.env[key]) == 'string')
+      result[key] = JSON.stringify(process.env[key]);
+  });
+
+  return result;
+}
+
 module.exports = {
   entry: {
     app: './lib/main.jsx',
@@ -24,6 +35,12 @@ module.exports = {
     ]
   },
   plugins: [
+    new webpack.DefinePlugin({
+      'process.env': importEnvVars([
+        'MAPBOX_ACCESS_TOKEN',
+        'MAPBOX_MAP_ID'
+      ])
+    }),
     new webpack.optimize.CommonsChunkPlugin('commons',
                                             'commons.bundle.js')
   ]


### PR DESCRIPTION
This fixes #191 by making it possible for the Mapbox access token and map ID to be overridden via environment variables at build time.

If/when we move to using a dynamic server instead of a static site generator, this mechanism should transfer to the new environment without any extra effort.