### PR TITLE
Fixes #270 - pages should include common.css instead of styles.css

### DIFF
--- a/lib/index-static.jsx
+++ b/lib/index-static.jsx
@@ -42,5 +42,5 @@ function generate(url, options, cb) {
 };
 
 exports.generate = generate;
-exports.CSS_FILENAME = "styles.css";
+exports.CSS_FILENAME = "common.css";
 exports.URLS = routes.URLS;


### PR DESCRIPTION
`common.css` is now compiled as a result of https://github.com/mozilla/teach.webmaker.org/blob/861165741ff9e8e683aa0af4fd45ea2a7d53c6d0/gulpfile.js#L95 :+1: :+1: :+1: 

Pages should now include `common.css` instead of `styles.css` (<- the one master stylesheet that we used to use before we [Modularize LESS code](https://github.com/mozilla/teach.webmaker.org/issues/226)) :wink: 