### PR TITLE
Add div.modal-backdrop to body when modal created/destroyed. And other modal things.

### DIFF
--- a/components/modal.jsx
+++ b/components/modal.jsx
@@ -14,17 +14,21 @@ var Modal = React.createClass({
     document.body.removeChild(this.backdrop);
     this.backdrop = null;
   },
-  handleClick: function(e) {
-    if (e.target === this.getDOMNode().querySelector("button.close")) {
+  handleCloseClick: function(e) {
+    this.props.onClose();
+  },
+  handleOutsideOfModalClick: function(e) {
+    if (e.target === this.getDOMNode()) {
       this.props.onClose();
     }
   },
   render: function() {
     return (
-      <div className="modal show">
-        <div className="modal-dialog" onClick={this.handleClick}>
+      <div className="modal show" onClick={this.handleOutsideOfModalClick}>
+        <div className="modal-dialog">
           <div className="modal-header">
-            <button type="button" className="close" aria-hidden="true">x</button>
+            <button type="button" className="close" aria-hidden="true"
+             onClick={this.handleCloseClick}>&times;</button>
             <div className="modal-title">{this.props.modalTitle}</div>
           </div>
           <div className="modal-body">

--- a/components/modal.jsx
+++ b/components/modal.jsx
@@ -9,16 +9,23 @@ var Modal = React.createClass({
     this.backdrop = document.createElement('div');
     this.backdrop.setAttribute('class', 'modal-backdrop');
     document.body.appendChild(this.backdrop);
+    document.addEventListener('keydown', this.handleKeyDown);
   },
   componentWillUnmount: function() {
     document.body.removeChild(this.backdrop);
     this.backdrop = null;
+    document.removeEventListener('keydown', this.handleKeyDown);
   },
   handleCloseClick: function(e) {
     this.props.onClose();
   },
   handleOutsideOfModalClick: function(e) {
     if (e.target === this.getDOMNode()) {
+      this.props.onClose();
+    }
+  },
+  handleKeyDown: function(e) {
+    if (e.which == 27) {
       this.props.onClose();
     }
   },

--- a/components/modal.jsx
+++ b/components/modal.jsx
@@ -5,6 +5,15 @@ var ReactAddons = require('react/addons');
 
 var Modal = React.createClass({
   mixins: [ReactAddons.PureRenderMixin],
+  componentDidMount: function() {
+    this.backdrop = document.createElement('div');
+    this.backdrop.setAttribute('class', 'modal-backdrop');
+    document.body.appendChild(this.backdrop);
+  },
+  componentWillUnmount: function() {
+    document.body.removeChild(this.backdrop);
+    this.backdrop = null;
+  },
   handleClick: function(e) {
     if (e.target === this.getDOMNode().querySelector("button.close")) {
       this.props.onClose();
@@ -13,7 +22,6 @@ var Modal = React.createClass({
   render: function() {
     return (
       <div className="modal show">
-        <div className="modal-backdrop"></div>
         <div className="modal-dialog" onClick={this.handleClick}>
           <div className="modal-header">
             <button type="button" className="close" aria-hidden="true">x</button>

--- a/components/modal.jsx
+++ b/components/modal.jsx
@@ -27,7 +27,7 @@ var Modal = React.createClass({
       <div className="modal show" onClick={this.handleOutsideOfModalClick}>
         <div className="modal-dialog">
           <div className="modal-header">
-            <button type="button" className="close" aria-hidden="true"
+            <button type="button" className="close"
              onClick={this.handleCloseClick}>&times;</button>
             <div className="modal-title">{this.props.modalTitle}</div>
           </div>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": " Initial attempt at implementing Webmaker Learning front-page.",
   "dependencies": {
-    "bootstrap": "^3.3.2",
+    "bootstrap": "^3.3.4",
     "es5-shim": "^4.1.0",
     "gulp": "^3.8.11",
     "gulp-autoprefixer": "^2.1.0",

--- a/test/browser/main.js
+++ b/test/browser/main.js
@@ -6,3 +6,4 @@ require('./imagetag.test.jsx');
 require('./routes.test.jsx');
 require('./teach-api.test.js');
 require('./login.test.jsx');
+require('./modal.test.jsx');

--- a/test/browser/modal.test.jsx
+++ b/test/browser/modal.test.jsx
@@ -26,6 +26,11 @@ describe("modal", function() {
 
   afterEach(removeModal);
 
+  it('closes modal when area outside modal is clicked', function() {
+    TestUtils.Simulate.click(modal.getDOMNode());
+    onClose.callCount.should.equal(1);
+  });
+
   it('closes modal when close button is clicked', function() {
     var closeButton = TestUtils.findRenderedDOMComponentWithClass(
       modal,

--- a/test/browser/modal.test.jsx
+++ b/test/browser/modal.test.jsx
@@ -1,0 +1,39 @@
+var should = require('should');
+var sinon = window.sinon;
+var React =require('react/addons');
+var TestUtils = React.addons.TestUtils;
+
+var Modal = require('../../components/modal.jsx');
+
+describe("modal", function() {
+  var modal, onClose;
+
+  function removeModal() {
+    if (modal) {
+      React.unmountComponentAtNode(modal.getDOMNode().parentNode);
+      modal = null;
+    }
+  }
+
+  beforeEach(function() {
+    onClose = sinon.spy();
+    modal = TestUtils.renderIntoDocument(
+      <Modal onClose={onClose}>
+        i am modal content
+      </Modal>
+    );
+  });
+
+  afterEach(removeModal);
+
+  it('creates body > .modal-backdrop when mounted', function() {
+    document.querySelectorAll('body > .modal-backdrop').length
+      .should.equal(1);
+  });
+
+  it('removes body > .modal-backdrop when mounted', function() {
+    removeModal();
+    document.querySelectorAll('body > .modal-backdrop').length
+      .should.equal(0);
+  });
+});

--- a/test/browser/modal.test.jsx
+++ b/test/browser/modal.test.jsx
@@ -31,7 +31,7 @@ describe("modal", function() {
       .should.equal(1);
   });
 
-  it('removes body > .modal-backdrop when mounted', function() {
+  it('removes body > .modal-backdrop when unmounted', function() {
     removeModal();
     document.querySelectorAll('body > .modal-backdrop').length
       .should.equal(0);

--- a/test/browser/modal.test.jsx
+++ b/test/browser/modal.test.jsx
@@ -26,6 +26,24 @@ describe("modal", function() {
 
   afterEach(removeModal);
 
+  it('closes modal when close button is clicked', function() {
+    var closeButton = TestUtils.findRenderedDOMComponentWithClass(
+      modal,
+      'close'
+    );
+    TestUtils.Simulate.click(closeButton);
+    onClose.callCount.should.equal(1);
+  });
+
+  it('does not close modal when title is clicked', function() {
+    var title = TestUtils.findRenderedDOMComponentWithClass(
+      modal,
+      'modal-title'
+    );
+    TestUtils.Simulate.click(title);
+    onClose.callCount.should.equal(0);
+  });
+
   it('creates body > .modal-backdrop when mounted', function() {
     document.querySelectorAll('body > .modal-backdrop').length
       .should.equal(1);

--- a/test/browser/modal.test.jsx
+++ b/test/browser/modal.test.jsx
@@ -26,6 +26,17 @@ describe("modal", function() {
 
   afterEach(removeModal);
 
+  it('closes modal if and only if ESC is pressed', function() {
+    // Ideally we'd fabricate a key event here, but doing
+    // that in a cross-browser way is actually non-trivial,
+    // so we'll just test the method.
+    modal.handleKeyDown({which: 13});
+    onClose.callCount.should.equal(0);
+
+    modal.handleKeyDown({which: 27});
+    onClose.callCount.should.equal(1);
+  });
+
   it('closes modal when area outside modal is clicked', function() {
     TestUtils.Simulate.click(modal.getDOMNode());
     onClose.callCount.should.equal(1);


### PR DESCRIPTION
The existing code puts a `.modal-backdrop` *inside* the modal, which prevents users from being able to type anything into the modal fields. This PR changes that behavior so that a `<div class="modal-backdrop">` is added to the `body` element when the modal is created, and removed when it's destroyed, similar to how [`bootstrap/modal.js`](https://github.com/twbs/bootstrap/blob/master/js/modal.js#L193-L194) does things.

It also adds tests to verify that the new functionality works, as well as existing functionality, which fixes #304.

@mmmavis can you review this?