### PR TITLE
Add viewport meta tag.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -225,6 +225,7 @@ gulp.task('watch', _.without(BUILD_TASKS, 'webpack'), function() {
       livereload: {
         enable: true
       },
+      host: '0.0.0.0',
       port: 8008
     }));
 });

--- a/lib/index-static.jsx
+++ b/lib/index-static.jsx
@@ -12,6 +12,7 @@ function generateWithPageHTML(url, options, pageHTML) {
       <head>
         <meta charSet="utf-8"/>
         <meta name="url" value={url}/>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,700,600italic,700italic,800,800italic"/>
         <link rel="stylesheet" href="/vendor/bootstrap/css/bootstrap.min.css"/>
         <link rel="stylesheet" href={'/' + exports.CSS_FILENAME}/>


### PR DESCRIPTION
This fixes a whole ton of issues with mobile usability, as outlined in #261.

It also makes the dev server reachable from the network, which makes mobile testing easier.

I tried this out on an iPhone 5, a OnePlus One, and an iPad, and the mobile version of the site looks *much* better on all of them.