### PR TITLE
Use contexts to manage modal display/hiding in an accessible way.

### DIFF
--- a/components/clubs-page.jsx
+++ b/components/clubs-page.jsx
@@ -123,9 +123,7 @@ var BottomCTA = React.createClass({
 var ModalAddYourClub = React.createClass({
   render: function() {
     return(
-      <Modal
-        modalTitle="Add Your Clubs To The Map"
-        onClose={this.props.onClose}>
+      <Modal modalTitle="Add Your Clubs To The Map">
         <form>
           <fieldset>
             <label>What is the name of your Club?</label>
@@ -154,9 +152,7 @@ var ModalAddYourClub = React.createClass({
 var ModalLearnMore = React.createClass({
   render: function() {
     return(
-      <Modal
-        modalTitle="Learn More About Hive Learning Clubs"
-        onClose={this.props.onClose}>
+      <Modal modalTitle="Learn More About Hive Learning Clubs">
         <form>
           <fieldset>
             <label>What is your first name?</label>
@@ -183,31 +179,22 @@ var ClubsPage = React.createClass({
   statics: {
     pageClassName: "clubs"
   },
-  getInitialState: function() {
-    return {
-      modalShown: {
-        ModalAddYourClub: false,
-        ModalLearnMore: false
-      }
-    };
+  contextTypes: {
+    showModal: React.PropTypes.func.isRequired
   },
-  closeModal: function(targetModal) {
-    var modalShownState = this.state.modalShown;
-    modalShownState[targetModal] = false;
-    this.setState(modalShownState);
+  showAddYourClubModal: function() {
+    this.context.showModal(ModalAddYourClub);
   },
-  showModal: function(targetModal) {
-    var modalShownState = this.state.modalShown;
-    modalShownState[targetModal] = true;
-    this.setState(modalShownState);
+  showLearnMoreModal: function() {
+    this.context.showModal(ModalLearnMore);
   },
   render: function() {
     return (
       <div>
         <HeroUnit image="/img/hero-clubs.jpg">
           <h1>Mozilla Learning Clubs</h1>
-          <div><a className="btn btn-awsm" onClick={this.showModal.bind(this,"ModalAddYourClub")}>Add Your Club</a></div>
-          <div><p className="learn-more">or <a onClick={this.showModal.bind(this,"ModalLearnMore")}>find out more</a> about us</p></div>
+          <div><a className="btn btn-awsm" onClick={this.showAddYourClubModal}>Add Your Club</a></div>
+          <div><p className="learn-more">or <a onClick={this.showLearnMoreModal}>find out more</a> about us</p></div>
         </HeroUnit>
         <section>
           <WebLitMap/>
@@ -225,14 +212,8 @@ var ClubsPage = React.createClass({
           <IconLinks/>
         </section>
         <section>
-          <BottomCTA onClick={this.showModal.bind(this,"ModalAddYourClub")} />
+          <BottomCTA onClick={this.showAddYourClubModal} />
         </section>
-        { this.state.modalShown.ModalAddYourClub
-          ? <ModalAddYourClub onClose={this.closeModal.bind(this,"ModalAddYourClub")} />
-          : null }
-        { this.state.modalShown.ModalLearnMore
-          ? <ModalLearnMore onClose={this.closeModal.bind(this,"ModalLearnMore")} />
-          : null }
       </div>
     );
   }

--- a/components/clubs-page.jsx
+++ b/components/clubs-page.jsx
@@ -9,6 +9,7 @@ var Blockquote = require('./blockquote.jsx');
 var IconLink = require('./icon-link.jsx');
 var PageEndCTA = require('./page-end-cta.jsx');
 var Modal = require('./modal.jsx');
+var ModalManagerMixin = require('../mixins/modal-manager');
 
 var WebLitMap = React.createClass({
   render: function() {
@@ -176,17 +177,15 @@ var ModalLearnMore = React.createClass({
 
 
 var ClubsPage = React.createClass({
+  mixins: [ModalManagerMixin],
   statics: {
     pageClassName: "clubs"
   },
-  contextTypes: {
-    showModal: React.PropTypes.func.isRequired
-  },
   showAddYourClubModal: function() {
-    this.context.showModal(ModalAddYourClub);
+    this.showModal(ModalAddYourClub);
   },
   showLearnMoreModal: function() {
-    this.context.showModal(ModalLearnMore);
+    this.showModal(ModalLearnMore);
   },
   render: function() {
     return (

--- a/components/modal.jsx
+++ b/components/modal.jsx
@@ -1,28 +1,24 @@
 var React = require('react');
 var ReactAddons = require('react/addons');
 
+var ModalManagerMixin = require('../mixins/modal-manager');
+
 var Modal = React.createClass({
-  mixins: [ReactAddons.PureRenderMixin],
-  contextTypes: {
-    hideModal: React.PropTypes.func.isRequired
-  },
+  mixins: [ReactAddons.PureRenderMixin, ModalManagerMixin],
   componentDidMount: function() {
     document.addEventListener('keydown', this.handleKeyDown);
   },
   componentWillUnmount: function() {
     document.removeEventListener('keydown', this.handleKeyDown);
   },
-  close: function() {
-    this.context.hideModal();
-  },
   handleOutsideOfModalClick: function(e) {
     if (e.target === this.getDOMNode()) {
-      this.close();
+      this.hideModal();
     }
   },
   handleKeyDown: function(e) {
     if (e.which == 27) {
-      this.close();
+      this.hideModal();
     }
   },
   render: function() {
@@ -34,7 +30,7 @@ var Modal = React.createClass({
         <div className="modal-dialog">
           <div className="modal-header">
             <button type="button" className="close"
-             onClick={this.close}>&times;</button>
+             onClick={this.hideModal}>&times;</button>
             <div className="modal-title" id="modal-label">
               {this.props.modalTitle}
             </div>

--- a/components/modal.jsx
+++ b/components/modal.jsx
@@ -1,42 +1,43 @@
-// [THIS LINE TO BE REMOVED] bootstrap class reference: http://nakupanda.github.io/bootstrap3-dialog/
-
 var React = require('react');
 var ReactAddons = require('react/addons');
 
 var Modal = React.createClass({
   mixins: [ReactAddons.PureRenderMixin],
+  contextTypes: {
+    hideModal: React.PropTypes.func.isRequired
+  },
   componentDidMount: function() {
-    this.backdrop = document.createElement('div');
-    this.backdrop.setAttribute('class', 'modal-backdrop');
-    document.body.appendChild(this.backdrop);
     document.addEventListener('keydown', this.handleKeyDown);
   },
   componentWillUnmount: function() {
-    document.body.removeChild(this.backdrop);
-    this.backdrop = null;
     document.removeEventListener('keydown', this.handleKeyDown);
   },
-  handleCloseClick: function(e) {
-    this.props.onClose();
+  close: function() {
+    this.context.hideModal();
   },
   handleOutsideOfModalClick: function(e) {
     if (e.target === this.getDOMNode()) {
-      this.props.onClose();
+      this.close();
     }
   },
   handleKeyDown: function(e) {
     if (e.which == 27) {
-      this.props.onClose();
+      this.close();
     }
   },
   render: function() {
     return (
-      <div className="modal show" onClick={this.handleOutsideOfModalClick}>
+      <div className="modal show"
+       role="dialog"
+       aria-labelledby="modal-label"
+       onClick={this.handleOutsideOfModalClick}>
         <div className="modal-dialog">
           <div className="modal-header">
             <button type="button" className="close"
-             onClick={this.handleCloseClick}>&times;</button>
-            <div className="modal-title">{this.props.modalTitle}</div>
+             onClick={this.close}>&times;</button>
+            <div className="modal-title" id="modal-label">
+              {this.props.modalTitle}
+            </div>
           </div>
           <div className="modal-body">
             {this.props.children}

--- a/components/page.jsx
+++ b/components/page.jsx
@@ -7,17 +7,49 @@ var Footer = require('./footer.jsx');
 
 var Page = React.createClass({
   mixins: [Router.State],
+  childContextTypes: {
+    showModal: React.PropTypes.func.isRequired,
+    hideModal: React.PropTypes.func.isRequired
+  },
+  getInitialState: function() {
+    return {
+      modalClass: null,
+      modalProps: null
+    }
+  },
+  showModal: function(modalClass, modalProps) {
+    this.setState({modalClass: modalClass, modalProps: modalProps});
+  },
+  hideModal: function() {
+    this.setState({modalClass: null, modalProps: null});
+  },
+  getChildContext: function() {
+    return {
+      showModal: this.showModal,
+      hideModal: this.hideModal
+    };
+  },
   render: function() {
     var pageClassName = this.getRoutes()[1].handler.pageClassName || '';
     return (
-      <div className={"page container-fluid " + pageClassName}>
-        <div className="row">
-          <Sidebar/>
-          <main className="content col-md-9">
-            <RouteHandler/>
-          </main>
+      <div>
+        <div className={"page container-fluid " + pageClassName}
+         aria-hidden={!!this.state.modalClass}>
+          <div className="row">
+            <Sidebar/>
+            <main className="content col-md-9">
+              <RouteHandler/>
+            </main>
+          </div>
+          <Footer/>
         </div>
-        <Footer/>
+        {this.state.modalClass
+         ? <div>
+             {React.createElement(this.state.modalClass,
+                                  this.state.modalProps)}
+             <div className="modal-backdrop"/>
+           </div>
+         : null}
       </div>
     );
   }

--- a/components/page.jsx
+++ b/components/page.jsx
@@ -29,12 +29,23 @@ var Page = React.createClass({
       hideModal: this.hideModal
     };
   },
+  // Accessibility best practices demand that only the elements in a
+  // modal be focusable while it's being displayed, so we'll enforce
+  // that here.
+  handleNonModalFocus: function(e) {
+    var firstFocusableEl = this.refs.modalHolder.getDOMNode()
+      .querySelector('a, button, input, textarea');
+    if (firstFocusableEl) {
+      firstFocusableEl.focus();
+    }
+  },
   render: function() {
     var pageClassName = this.getRoutes()[1].handler.pageClassName || '';
     return (
       <div>
         <div className={"page container-fluid " + pageClassName}
-         aria-hidden={!!this.state.modalClass}>
+         aria-hidden={!!this.state.modalClass}
+         onFocus={this.state.modalClass && this.handleNonModalFocus}>
           <div className="row">
             <Sidebar/>
             <main className="content col-md-9">
@@ -44,7 +55,7 @@ var Page = React.createClass({
           <Footer/>
         </div>
         {this.state.modalClass
-         ? <div>
+         ? <div ref="modalHolder">
              {React.createElement(this.state.modalClass,
                                   this.state.modalProps)}
              <div className="modal-backdrop"/>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,6 +183,7 @@ gulp.task('watch', _.without(BUILD_TASKS, 'webpack'), function() {
   gulp.watch([
     'lib/**',
     'components/**',
+    'mixins/**',
     'pages/**'
   ], function() {
     gutil.log('Rebuilding index HTML files.');

--- a/mixins/modal-manager.js
+++ b/mixins/modal-manager.js
@@ -1,0 +1,14 @@
+var React = require('react');
+
+module.exports = {
+  contextTypes: {
+    showModal: React.PropTypes.func.isRequired,
+    hideModal: React.PropTypes.func.isRequired
+  },
+  showModal: function(modalClass, modalProps) {
+    this.context.showModal(modalClass, modalProps);
+  },
+  hideModal: function() {
+    this.context.hideModal();
+  }
+};

--- a/test/browser/modal.test.jsx
+++ b/test/browser/modal.test.jsx
@@ -5,26 +5,38 @@ var TestUtils = React.addons.TestUtils;
 
 var Modal = require('../../components/modal.jsx');
 
-describe("modal", function() {
-  var modal, onClose;
-
-  function removeModal() {
-    if (modal) {
-      React.unmountComponentAtNode(modal.getDOMNode().parentNode);
-      modal = null;
-    }
+var FakePage = React.createClass({
+  childContextTypes: {
+    hideModal: React.PropTypes.func.isRequired
+  },
+  getChildContext: function() {
+    return {
+      hideModal: this.props.onHideModal
+    };
+  },
+  render: function() {
+    return (
+      <div>
+        <Modal ref="modal">
+          i am modal content
+        </Modal>
+      </div>
+    );
   }
+});
+
+describe("modal", function() {
+  var page, modal, onClose;
 
   beforeEach(function() {
     onClose = sinon.spy();
-    modal = TestUtils.renderIntoDocument(
-      <Modal onClose={onClose}>
-        i am modal content
-      </Modal>
-    );
+    page = TestUtils.renderIntoDocument(<FakePage onHideModal={onClose}/>);
+    modal = page.refs.modal;
   });
 
-  afterEach(removeModal);
+  afterEach(function() {
+    React.unmountComponentAtNode(page.getDOMNode().parentNode);
+  });
 
   it('closes modal if and only if ESC is pressed', function() {
     // Ideally we'd fabricate a key event here, but doing
@@ -58,16 +70,5 @@ describe("modal", function() {
     );
     TestUtils.Simulate.click(title);
     onClose.callCount.should.equal(0);
-  });
-
-  it('creates body > .modal-backdrop when mounted', function() {
-    document.querySelectorAll('body > .modal-backdrop').length
-      .should.equal(1);
-  });
-
-  it('removes body > .modal-backdrop when unmounted', function() {
-    removeModal();
-    document.querySelectorAll('body > .modal-backdrop').length
-      .should.equal(0);
   });
 });

--- a/test/browser/modal.test.jsx
+++ b/test/browser/modal.test.jsx
@@ -7,11 +7,15 @@ var Modal = require('../../components/modal.jsx');
 
 var FakePage = React.createClass({
   childContextTypes: {
-    hideModal: React.PropTypes.func.isRequired
+    hideModal: React.PropTypes.func.isRequired,
+    showModal: React.PropTypes.func.isRequired
   },
   getChildContext: function() {
     return {
-      hideModal: this.props.onHideModal
+      hideModal: this.props.onHideModal,
+      showModal: function() {
+        throw new Error("this should never be called");
+      }
     };
   },
   render: function() {


### PR DESCRIPTION
This fixes a number of issues with the modals introduced in #269:

* It positions the modal as a sibling element to the page content, which allows us to give the page content an `aria-hidden="true"` attribute while modals are showing, which is a best practice for accessibility (see [The Incredible Accessible Modal Window](http://accessibility.oit.ncsu.edu/training/aria/modal-window/version-3/) feature 3).
* It ensures that while a modal is shown, other interactive elements on the page can't be focused with the keyboard (see *The Incredible Accessible Modal Window* feature 4).
* It uses [React Contexts](https://www.tildedave.com/2014/11/15/introduction-to-contexts-in-react-js.html) to manage the showing/hiding of modals, which significantly simplifies logic for pages that need to show modals. Now they just use the `ModalManagerMixin` and call `this.showModal(SomeModalClass, {someProp: "blah"})` whenever they want to show a modal.

This PR fixes #301.

TODOs:

- [x] Move the modal functionality into a mixin, so components that want to display modals don't need to define `contextTypes`.
