### PR TITLE
Makes the blockquote component a little less heavy-handed.

### DIFF
--- a/components/blockquote.jsx
+++ b/components/blockquote.jsx
@@ -3,7 +3,7 @@ var ImageTag = require('./imagetag.jsx');
 
 var Blockquote = React.createClass({
   propTypes: {
-    className: React.PropTypes.string.isRequired,
+    className: React.PropTypes.string,
     imgSrc: React.PropTypes.string.isRequired,
     imgSrc2x: React.PropTypes.string,
     imgAlt: React.PropTypes.string.isRequired,
@@ -15,7 +15,7 @@ var Blockquote = React.createClass({
     return (
       <blockquote className={this.props.className}>
         <figure>
-          <ImageTag src1x={this.props.imgSrc} src2x={this.props.imgSrc2x || this.props.imgSrc}
+          <ImageTag src1x={this.props.imgSrc} src2x={this.props.imgSrc2x}
               alt={this.props.imgAlt} width={this.props.imgWidth || 148} />
         </figure>
         {this.props.children}


### PR DESCRIPTION
I looked at the existing blockquotes and there's no reason the className should be required. Also, the imagetag component can take it if there isn't a src2x, so we may as well not lie to it about the source.