### PR TITLE
Add a Teach API Client mixin

### DIFF
--- a/components/login.jsx
+++ b/components/login.jsx
@@ -2,31 +2,25 @@ var React = require('react');
 var Router = require('react-router');
 var Link = Router.Link;
 
-var teachAPI = require('../lib/teach-api');
+var TeachAPIClientMixin = require('../mixins/teach-api-client');
 
 var Login = React.createClass({
+  mixins: [TeachAPIClientMixin],
+  statics: {
+    teachAPIEvents: {
+      'login:error': 'handleApiLoginError',
+      'login:cancel': 'handleApiLoginCancel',
+      'login:success': 'handleApiLoginSuccess',
+      'logout': 'handleApiLogout'
+    }
+  },
   getDefaultProps: function() {
     return {
-      teachAPI: teachAPI,
       alert: defaultAlert
     };
   },
   componentDidMount: function() {
-    var teachAPI = this.props.teachAPI;
-
-    teachAPI.on('login:error', this.handleApiLoginError);
-    teachAPI.on('login:cancel', this.handleApiLoginCancel);
-    teachAPI.on('login:success', this.handleApiLoginSuccess);
-    teachAPI.on('logout', this.handleApiLogout);
-    this.setState({username: teachAPI.getUsername()});
-  },
-  componentWillUnmount: function() {
-    var teachAPI = this.props.teachAPI;
-
-    teachAPI.removeListener('login:error', this.handleApiLoginError);
-    teachAPI.removeListener('login:cancel', this.handleApiLoginCancel);
-    teachAPI.removeListener('login:success', this.handleApiLoginSuccess);
-    teachAPI.removeListener('logout', this.handleApiLogout);
+    this.setState({username: this.getTeachAPI().getUsername()});
   },
   getInitialState: function() {
     return {
@@ -37,11 +31,11 @@ var Login = React.createClass({
   handleLoginClick: function(e) {
     e.preventDefault();
     this.setState({loggingIn: true});
-    this.props.teachAPI.startLogin();
+    this.getTeachAPI().startLogin();
   },
   handleLogoutClick: function(e) {
     e.preventDefault();
-    this.props.teachAPI.logout();
+    this.getTeachAPI().logout();
   },
   handleApiLoginError: function(err) {
     this.setState({loggingIn: false});
@@ -64,7 +58,7 @@ var Login = React.createClass({
     this.setState({loggingIn: false});
   },
   handleApiLoginSuccess: function(info) {
-    this.setState({username: this.props.teachAPI.getUsername(),
+    this.setState({username: this.getTeachAPI().getUsername(),
                    loggingIn: false});
   },
   handleApiLogout: function() {

--- a/components/map.jsx
+++ b/components/map.jsx
@@ -1,7 +1,8 @@
 var React = require('react');
 var mapboxId = process.env.MAPBOX_MAP_ID || 'alicoding.ldmhe4f3';
 var accessToken = process.env.MAPBOX_ACCESS_TOKEN || 'pk.eyJ1IjoiYWxpY29kaW5nIiwiYSI6Il90WlNFdE0ifQ.QGGdXGA_2QH-6ujyZE2oSg';
-var teachAPI = require('../lib/teach-api');
+
+var TeachAPIClientMixin = require('../mixins/teach-api-client');
 
 function geoJSONit(data) {
   return data.map(function(i) {
@@ -21,6 +22,7 @@ function geoJSONit(data) {
 }
 
 var Map = React.createClass({
+  mixins: [TeachAPIClientMixin],
   propTypes: {
     className: React.PropTypes.string.isRequired
   },
@@ -29,7 +31,7 @@ var Map = React.createClass({
     require('mapbox.js'); // this will automatically attach to Window object.
     require('leaflet.markercluster');
     L.mapbox.accessToken = accessToken;
-    teachAPI.getAllClubsData(function(err, data) {
+    this.getTeachAPI().getAllClubsData(function(err, data) {
       if (!that.isMounted()) {
         // We were unmounted before the API request completed,
         // so do nothing.

--- a/components/page.jsx
+++ b/components/page.jsx
@@ -4,12 +4,14 @@ var RouteHandler = Router.RouteHandler;
 
 var Sidebar = require('./sidebar.jsx');
 var Footer = require('./footer.jsx');
+var TeachAPI = require('../lib/teach-api');
 
 var Page = React.createClass({
   mixins: [Router.State],
   childContextTypes: {
     showModal: React.PropTypes.func.isRequired,
-    hideModal: React.PropTypes.func.isRequired
+    hideModal: React.PropTypes.func.isRequired,
+    teachAPI: React.PropTypes.object.isRequired
   },
   getInitialState: function() {
     return {
@@ -23,10 +25,17 @@ var Page = React.createClass({
   hideModal: function() {
     this.setState({modalClass: null, modalProps: null});
   },
+  getTeachAPI: function() {
+    if (!this.teachAPI) {
+      this.teachAPI = new TeachAPI();
+    }
+    return this.teachAPI;
+  },
   getChildContext: function() {
     return {
       showModal: this.showModal,
-      hideModal: this.hideModal
+      hideModal: this.hideModal,
+      teachAPI: this.getTeachAPI()
     };
   },
   // Accessibility best practices demand that only the elements in a

--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -86,5 +86,4 @@ _.extend(TeachAPI.prototype, {
   }
 });
 
-module.exports = new TeachAPI();
-module.exports.TeachAPI = TeachAPI;
+module.exports = TeachAPI;

--- a/mixins/teach-api-client.js
+++ b/mixins/teach-api-client.js
@@ -1,0 +1,58 @@
+// TeachAPIClientMixin is a React mixin that can be used by any component
+// that needs direct access to the Teach API.
+//
+// The component can access the Teach API via the getTeachAPI() method.
+//
+// If the component defines a static object called 'teachAPIEvents' like so:
+//
+// var Foo = React.createClass({
+//   statics: {
+//     teachAPIEvents: {
+//       'logout': 'handleLogout'
+//     }
+//   }
+//
+// The mixin will ensure that the handleLogout() method is called whenever
+// the 'logout' event occurs in the Teach API. The mixin takes care of
+// unbinding the event listener when the component unmounts.
+
+var React = require('react');
+
+module.exports = {
+  contextTypes: {
+    teachAPI: React.PropTypes.object.isRequired
+  },
+  getTeachAPI: function() {
+    return this.context.teachAPI;
+  },
+  componentDidMount: function() {
+    var displayName = this.constructor.displayName;
+    var events = this.constructor.teachAPIEvents;
+
+    if (events) {
+      Object.keys(events).forEach(function(event) {
+        var methodName = events[event];
+        var method = this[methodName];
+        if (typeof(method) != 'function') {
+          console.warn('method ' + displayName + '::' + methodName +
+                       ' does not exist');
+          return;
+        }
+        this.context.teachAPI.on(event, method);
+      }, this);
+    }
+  },
+  componentWillUnmount: function() {
+    var events = this.constructor.teachAPIEvents;
+
+    if (events) {
+      Object.keys(events).forEach(function(event) {
+        var methodName = events[event];
+        var method = this[methodName];
+        if (typeof(method) == 'function') {
+          this.context.teachAPI.removeListener(event, method);
+        }
+      }, this);
+    }
+  }
+};

--- a/test/browser/imagetag.test.jsx
+++ b/test/browser/imagetag.test.jsx
@@ -1,5 +1,5 @@
 var should = require('should');
-var stubRouterContext = require('./stub-router-context.jsx');
+var stubContext = require('./stub-context.jsx');
 
 var ImageTag = require('../../components/imagetag.jsx');
 
@@ -8,7 +8,7 @@ describe('ImageTag', function () {
       imagetag;
 
   beforeEach(function() {
-    imagetag = stubRouterContext.render(ImageTag, {
+    imagetag = stubContext.render(ImageTag, {
       alt: 'Foo',
       src1x: 'foo1x.jpg',
       src2x: 'foo2x.jpg'
@@ -16,7 +16,7 @@ describe('ImageTag', function () {
   });
 
   afterEach(function() {
-    stubRouterContext.unmount(imagetag);
+    stubContext.unmount(imagetag);
   });
 
   it('should detect pixel density and set state accordingly', function () {

--- a/test/browser/login.test.jsx
+++ b/test/browser/login.test.jsx
@@ -1,33 +1,28 @@
 var EventEmitter = require('events').EventEmitter;
 var should = require('should');
-var sinon = window.sinon;
 var React =require('react/addons');
 var TestUtils = React.addons.TestUtils;
 
-var stubRouterContext = require('./stub-router-context.jsx');
+var stubContext = require('./stub-context.jsx');
 var Login = require('../../components/login.jsx');
+var StubTeachAPI = require('./stub-teach-api');
 
 describe("login", function() {
-  var login, teachAPI, username, alerts;
+  var login, teachAPI, alerts;
 
   beforeEach(function() {
-    teachAPI = new EventEmitter();
-    username = null;
+    teachAPI = new StubTeachAPI();
     alerts = [];
-    teachAPI.logout = sinon.spy();
-    teachAPI.startLogin = sinon.spy();
-    teachAPI.getUsername = function() {
-      return username;
-    };
-    login = stubRouterContext.render(Login, {
-      teachAPI: teachAPI,
+    login = stubContext.render(Login, {
       alert: function(msg) { alerts.push(msg); }
+    }, {
+      teachAPI: teachAPI
     });
   });
 
   afterEach(function() {
     if (login) {
-      stubRouterContext.unmount(login);
+      stubContext.unmount(login);
     }
   });
 
@@ -43,7 +38,7 @@ describe("login", function() {
       EventEmitter.listenerCount(teachAPI, event).should.equal(1);
     });
 
-    stubRouterContext.unmount(login);
+    stubContext.unmount(login);
 
     events.forEach(function(event) {
       EventEmitter.listenerCount(teachAPI, event).should.equal(0);
@@ -102,7 +97,7 @@ describe("login", function() {
 
   it("handles login:success event", function() {
     login.setState({loggingIn: true});
-    username = "foo";
+    teachAPI.getUsername.returns("foo");
     teachAPI.emit('login:success');
     login.state.loggingIn.should.be.false;
     login.state.username.should.eql("foo");

--- a/test/browser/main.js
+++ b/test/browser/main.js
@@ -3,7 +3,6 @@ process.env.NODE_ENV = 'test';
 require('./config.test.js');
 require('./sidebar.test.jsx');
 require('./imagetag.test.jsx');
-require('./routes.test.jsx');
 require('./teach-api.test.js');
 require('./login.test.jsx');
 require('./modal.test.jsx');

--- a/test/browser/routes.test.jsx
+++ b/test/browser/routes.test.jsx
@@ -5,14 +5,12 @@ var TestUtils = React.addons.TestUtils;
 var Router = require('react-router');
 var Link = Router.Link;
 
-var teachAPI = require('../../lib/teach-api.js');
 var routes = require('../../lib/routes.jsx');
 
 describe('routes', function() {
   require('mapbox.js');
 
   beforeEach(function() {
-    sinon.stub(teachAPI, 'getAllClubsData');
     sinon.stub(L.mapbox, 'map', function() {
       return {
         remove: function() {return this;},
@@ -47,7 +45,6 @@ describe('routes', function() {
   });
 
   afterEach(function() {
-    teachAPI.getAllClubsData.restore();
     L.mapbox.map.restore();
     L.mapbox.featureLayer.restore();
   });

--- a/test/browser/sidebar.test.jsx
+++ b/test/browser/sidebar.test.jsx
@@ -2,14 +2,14 @@ var should = require('should');
 var React =require('react/addons');
 var TestUtils = React.addons.TestUtils;
 
-var stubRouterContext = require('./stub-router-context.jsx');
+var stubContext = require('./stub-context.jsx');
 var Sidebar = require('../../components/sidebar.jsx');
 
 describe("sidebar", function() {
   var sidebar, hamburger, collapsibleContent;
 
   beforeEach(function() {
-    sidebar = stubRouterContext.render(Sidebar, {});
+    sidebar = stubContext.render(Sidebar, {});
     hamburger = TestUtils.findRenderedDOMComponentWithClass(
       sidebar,
       'glyphicon-menu-hamburger'
@@ -21,7 +21,7 @@ describe("sidebar", function() {
   });
 
   afterEach(function() {
-    stubRouterContext.unmount(sidebar);
+    stubContext.unmount(sidebar);
   });
 
   it('should hide collapsed content by default', function() {

--- a/test/browser/stub-context.jsx
+++ b/test/browser/stub-context.jsx
@@ -1,10 +1,13 @@
+// This is based on:
 // https://github.com/rackt/react-router/blob/master/docs/guides/testing.md
 
 var _ = require('underscore');
 var React =require('react/addons');
 var TestUtils = React.addons.TestUtils;
 
-var stubRouterContext = function(Component, props, stubs) {
+var StubTeachAPI = require('./stub-teach-api');
+
+var stubContext = function(Component, props, stubs) {
   var func = React.PropTypes.func;
   var noop = function() {};
 
@@ -21,6 +24,7 @@ var stubRouterContext = function(Component, props, stubs) {
       getCurrentParams: func,
       getCurrentQuery: func,
       isActive: func,
+      teachAPI: React.PropTypes.object
     },
 
     getChildContext: function() {
@@ -35,7 +39,8 @@ var stubRouterContext = function(Component, props, stubs) {
         getCurrentPathname: noop,
         getCurrentParams: noop,
         getCurrentQuery: noop,
-        isActive: noop
+        isActive: noop,
+        teachAPI: new StubTeachAPI()
       }, stubs);
     },
 
@@ -45,13 +50,13 @@ var stubRouterContext = function(Component, props, stubs) {
   });
 };
 
-stubRouterContext.render = function(Component, props) {
-  var Stubbed = stubRouterContext(Component, props);
+stubContext.render = function(Component, props, stubs) {
+  var Stubbed = stubContext(Component, props, stubs);
   return TestUtils.renderIntoDocument(<Stubbed/>).refs.unstubbed;
 };
 
-stubRouterContext.unmount = function(unstubbed) {
+stubContext.unmount = function(unstubbed) {
   React.unmountComponentAtNode(unstubbed.getDOMNode().parentNode);
 };
 
-module.exports = stubRouterContext;
+module.exports = stubContext;

--- a/test/browser/stub-teach-api.js
+++ b/test/browser/stub-teach-api.js
@@ -1,0 +1,15 @@
+var EventEmitter = require('events').EventEmitter;
+var sinon = window.sinon;
+
+function StubTeachAPI() {
+  var teachAPI = new EventEmitter();
+
+  teachAPI.logout = sinon.spy();
+  teachAPI.startLogin = sinon.spy();
+  teachAPI.getUsername = sinon.stub();
+  teachAPI.getAllClubsData = sinon.spy();
+
+  return teachAPI;
+}
+
+module.exports = StubTeachAPI;

--- a/test/browser/teach-api.test.js
+++ b/test/browser/teach-api.test.js
@@ -1,7 +1,7 @@
 var should = require('should');
 var sinon = window.sinon;
 
-var TeachAPI = require('../../lib/teach-api').TeachAPI;
+var TeachAPI = require('../../lib/teach-api');
 
 describe('TeachAPI', function() {
   var xhr, requests, storage;


### PR DESCRIPTION
This PR does a number of things:

* Components now access the Teach API via a mixin rather than a global singleton. This is ultimately done via [React Contexts](https://www.tildedave.com/2014/11/15/introduction-to-contexts-in-react-js.html); since we're already using them ourselves as of #312, I figured we might as well use them here too. Among other things, it allows for less error-prone event binding.
* The `stub-router-context` module is now called the `stub-context`, as it stubs out the Teach API too.
* A new `stub-teach-api` module can be used to stub out the Teach API in nifty ways for testing. `login.test.jsx` has been modified to use it.
* The `routes.test.jsx` module is gone now; it was a very fragile test that was a pain to constantly fix, and didn't actually test anything particularly useful. It'll be easier to just monkeypatch the `Link` tag at runtime to log a warning if any Links are ever created that are referred to by path instead of route name.
