### PR TITLE
Implement rudimentary club creation and deletion

### DIFF
--- a/components/clubs-page.jsx
+++ b/components/clubs-page.jsx
@@ -180,26 +180,21 @@ var ModalLearnMore = React.createClass({
 var ClubsPage = React.createClass({
   mixins: [ModalManagerMixin, TeachAPIClientMixin],
   statics: {
+    teachAPIEvents: {
+      'clubs:change': 'handleClubsChange'
+    },
     pageClassName: "clubs"
   },
   getInitialState: function() {
     return {
-      clubs: []
+      clubs: this.getTeachAPI().getClubs()
     };
   },
   componentDidMount: function() {
-    this.getTeachAPI().getAllClubsData(function(err, data) {
-      if (!this.isMounted()) {
-        // We were unmounted before the API request completed,
-        // so do nothing.
-        return;
-      }
-      if (err) {
-        console.log(err)
-        return;
-      }
-      this.setState({clubs: data});
-    }.bind(this));
+    this.getTeachAPI().updateClubs();
+  },
+  handleClubsChange: function(clubs) {
+    this.setState({clubs: clubs});
   },
   showAddYourClubModal: function() {
     this.showModal(ModalAddYourClub);

--- a/components/clubs-page.jsx
+++ b/components/clubs-page.jsx
@@ -220,27 +220,13 @@ var ClubsPage = React.createClass({
   mixins: [ModalManagerMixin, TeachAPIClientMixin],
   statics: {
     teachAPIEvents: {
-      'clubs:change': 'handleClubsChange',
-      'username:change': 'handleUsernameChange'
+      'clubs:change': 'forceUpdate',
+      'username:change': 'forceUpdate'
     },
     pageClassName: "clubs"
   },
-  getInitialState: function() {
-    var teachAPI = this.getTeachAPI();
-
-    return {
-      clubs: teachAPI.getClubs(),
-      username: teachAPI.getUsername()
-    };
-  },
   componentDidMount: function() {
     this.getTeachAPI().updateClubs();
-  },
-  handleUsernameChange: function(username) {
-    this.setState({username: username});
-  },
-  handleClubsChange: function(clubs) {
-    this.setState({clubs: clubs});
   },
   showAddYourClubModal: function() {
     if (!this.getTeachAPI().getUsername()) {
@@ -263,6 +249,10 @@ var ClubsPage = React.createClass({
     window.alert("Sorry, club editing has not yet been implemented.");
   },
   render: function() {
+    var teachAPI = this.getTeachAPI();
+    var clubs = teachAPI.getClubs();
+    var username = teachAPI.getUsername();
+
     return (
       <div>
         <HeroUnit image="/img/hero-clubs.jpg">
@@ -274,8 +264,8 @@ var ClubsPage = React.createClass({
           <WebLitMap/>
           <div className="mapDiv" id="mapDivID">
             <Map className="mapDivChild"
-             clubs={this.state.clubs}
-             username={this.state.username}
+             clubs={clubs}
+             username={username}
              onDelete={this.handleClubDelete}
              onEdit={this.handleClubEdit}/>
           </div>

--- a/components/clubs-page.jsx
+++ b/components/clubs-page.jsx
@@ -1,4 +1,5 @@
-var React = require('react');
+var _ = require('underscore');
+var React = require('react/addons');
 var Router = require('react-router');
 var Link = Router.Link;
 
@@ -123,9 +124,31 @@ var BottomCTA = React.createClass({
 
 
 var ModalAddYourClub = React.createClass({
+  mixins: [React.addons.LinkedStateMixin, ModalManagerMixin],
+  propTypes: {
+    onAddClub: React.PropTypes.func.isRequired
+  },
+  getInitialState: function() {
+    return {
+      name: '',
+      website: '',
+      description: '',
+      location: ''
+    };
+  },
   handleSubmit: function(e) {
     e.preventDefault();
-    window.alert("Sorry, this functionality has not yet been implemented.");
+    this.props.onAddClub(_.pick(this.state,
+      'name', 'website', 'description', 'location'
+    ), function(err) {
+      if (err) {
+        window.alert("Alas, an error occurred. Please try again later!");
+        console.log(err);
+      } else {
+        window.alert("Your club has been added!");
+        this.hideModal();
+      }
+    }.bind(this));
   },
   render: function() {
     return(
@@ -133,19 +156,27 @@ var ModalAddYourClub = React.createClass({
         <form onSubmit={this.handleSubmit}>
           <fieldset>
             <label>What is the name of your Club?</label>
-            <input type="text" placeholder="We love creative Club names" />
+            <input type="text" placeholder="We love creative Club names"
+             required
+             valueLink={this.linkState('name')} />
           </fieldset>
           <fieldset>
             <label>Where does it take place?</label>
-            <input type="text" placeholder="Type in a city or a country" />
+            <input type="text" placeholder="Type in a city or a country"
+             required
+             valueLink={this.linkState('location')} />
           </fieldset>
           <fieldset>
-            <label>Does your Club have a website?</label>
-            <input type="text" placeholder="www.myclubwebsite.com" />
+            <label>What is your Club's website?</label>
+            <input type="url" placeholder="http://www.myclubwebsite.com"
+             required
+             valueLink={this.linkState('website')} />
           </fieldset>
           <fieldset>
             <label>What do you focus your efforts on?</label>
-            <textarea rows="5" placeholder="Give us a brief description about what your Club is about." />
+            <textarea rows="5" placeholder="Give us a brief description about what your Club is about."
+             required
+             valueLink={this.linkState('description')} />
           </fieldset>
           <input type="submit" className="btn" value="Add Your Club To The Map" />
         </form>
@@ -205,7 +236,13 @@ var ClubsPage = React.createClass({
     this.setState({clubs: clubs});
   },
   showAddYourClubModal: function() {
-    this.showModal(ModalAddYourClub);
+    if (!this.getTeachAPI().getUsername()) {
+      window.alert("You need to log in before you can add a club!");
+      return;
+    }
+    this.showModal(ModalAddYourClub, {
+      onAddClub: this.getTeachAPI().addClub
+    });
   },
   showLearnMoreModal: function() {
     this.showModal(ModalLearnMore);

--- a/components/clubs-page.jsx
+++ b/components/clubs-page.jsx
@@ -167,7 +167,7 @@ var ModalAddYourClub = React.createClass({
              valueLink={this.linkState('location')} />
           </fieldset>
           <fieldset>
-            <label>What is your Club's website?</label>
+            <label>What is your Club&lsquo;s website?</label>
             <input type="url" placeholder="http://www.myclubwebsite.com"
              required
              valueLink={this.linkState('website')} />

--- a/components/clubs-page.jsx
+++ b/components/clubs-page.jsx
@@ -10,6 +10,7 @@ var IconLink = require('./icon-link.jsx');
 var PageEndCTA = require('./page-end-cta.jsx');
 var Modal = require('./modal.jsx');
 var ModalManagerMixin = require('../mixins/modal-manager');
+var TeachAPIClientMixin = require('../mixins/teach-api-client');
 
 var WebLitMap = React.createClass({
   render: function() {
@@ -177,9 +178,28 @@ var ModalLearnMore = React.createClass({
 
 
 var ClubsPage = React.createClass({
-  mixins: [ModalManagerMixin],
+  mixins: [ModalManagerMixin, TeachAPIClientMixin],
   statics: {
     pageClassName: "clubs"
+  },
+  getInitialState: function() {
+    return {
+      clubs: []
+    };
+  },
+  componentDidMount: function() {
+    this.getTeachAPI().getAllClubsData(function(err, data) {
+      if (!this.isMounted()) {
+        // We were unmounted before the API request completed,
+        // so do nothing.
+        return;
+      }
+      if (err) {
+        console.log(err)
+        return;
+      }
+      this.setState({clubs: data});
+    }.bind(this));
   },
   showAddYourClubModal: function() {
     this.showModal(ModalAddYourClub);
@@ -198,8 +218,8 @@ var ClubsPage = React.createClass({
         <section>
           <WebLitMap/>
           <div className="mapDiv" id="mapDivID">
-            <Map className={'mapDivChild'} />
-           </div>
+            <Map className="mapDivChild" clubs={this.state.clubs} />
+          </div>
         </section>
         <section>
           <HowClubWorks/>

--- a/components/clubs-page.jsx
+++ b/components/clubs-page.jsx
@@ -220,17 +220,25 @@ var ClubsPage = React.createClass({
   mixins: [ModalManagerMixin, TeachAPIClientMixin],
   statics: {
     teachAPIEvents: {
-      'clubs:change': 'handleClubsChange'
+      'clubs:change': 'handleClubsChange',
+      'login:success': 'handleLoginChange',
+      'logout': 'handleLoginChange'
     },
     pageClassName: "clubs"
   },
   getInitialState: function() {
+    var teachAPI = this.getTeachAPI();
+
     return {
-      clubs: this.getTeachAPI().getClubs()
+      clubs: teachAPI.getClubs(),
+      username: teachAPI.getUsername()
     };
   },
   componentDidMount: function() {
     this.getTeachAPI().updateClubs();
+  },
+  handleLoginChange: function() {
+    this.setState({username: this.getTeachAPI().getUsername()});
   },
   handleClubsChange: function(clubs) {
     this.setState({clubs: clubs});
@@ -247,6 +255,14 @@ var ClubsPage = React.createClass({
   showLearnMoreModal: function() {
     this.showModal(ModalLearnMore);
   },
+  handleClubDelete: function(url) {
+    console.log(url);
+    window.alert("Sorry, club deletion has not yet been implemented.");
+  },
+  handleClubEdit: function(url) {
+    console.log(url);
+    window.alert("Sorry, club editing has not yet been implemented.");
+  },
   render: function() {
     return (
       <div>
@@ -258,7 +274,11 @@ var ClubsPage = React.createClass({
         <section>
           <WebLitMap/>
           <div className="mapDiv" id="mapDivID">
-            <Map className="mapDivChild" clubs={this.state.clubs} />
+            <Map className="mapDivChild"
+             clubs={this.state.clubs}
+             username={this.state.username}
+             onDelete={this.handleClubDelete}
+             onEdit={this.handleClubEdit}/>
           </div>
         </section>
         <section>

--- a/components/clubs-page.jsx
+++ b/components/clubs-page.jsx
@@ -123,10 +123,14 @@ var BottomCTA = React.createClass({
 
 
 var ModalAddYourClub = React.createClass({
+  handleSubmit: function(e) {
+    e.preventDefault();
+    window.alert("Sorry, this functionality has not yet been implemented.");
+  },
   render: function() {
     return(
-      <Modal modalTitle="Add Your Clubs To The Map">
-        <form>
+      <Modal modalTitle="Add Your Club To The Map">
+        <form onSubmit={this.handleSubmit}>
           <fieldset>
             <label>What is the name of your Club?</label>
             <input type="text" placeholder="We love creative Club names" />
@@ -152,13 +156,17 @@ var ModalAddYourClub = React.createClass({
 
 
 var ModalLearnMore = React.createClass({
+  handleSubmit: function(e) {
+    e.preventDefault();
+    window.alert("Sorry, this functionality has not yet been implemented.");
+  },
   render: function() {
     return(
       <Modal modalTitle="Learn More About Hive Learning Clubs">
-        <form>
+        <form onSubmit={this.handleSubmit}>
           <fieldset>
             <label>What is your first name?</label>
-            <input type="text" placeholder="We're a friendly bunch, promised!" />
+            <input type="text" placeholder="We're a friendly bunch, promise!" />
           </fieldset>
           <fieldset>
             <label>Where does it take place?</label>

--- a/components/clubs-page.jsx
+++ b/components/clubs-page.jsx
@@ -221,8 +221,7 @@ var ClubsPage = React.createClass({
   statics: {
     teachAPIEvents: {
       'clubs:change': 'handleClubsChange',
-      'login:success': 'handleLoginChange',
-      'logout': 'handleLoginChange'
+      'username:change': 'handleUsernameChange'
     },
     pageClassName: "clubs"
   },
@@ -237,8 +236,8 @@ var ClubsPage = React.createClass({
   componentDidMount: function() {
     this.getTeachAPI().updateClubs();
   },
-  handleLoginChange: function() {
-    this.setState({username: this.getTeachAPI().getUsername()});
+  handleUsernameChange: function(username) {
+    this.setState({username: username});
   },
   handleClubsChange: function(clubs) {
     this.setState({clubs: clubs});

--- a/components/clubs-page.jsx
+++ b/components/clubs-page.jsx
@@ -240,9 +240,21 @@ var ClubsPage = React.createClass({
   showLearnMoreModal: function() {
     this.showModal(ModalLearnMore);
   },
-  handleClubDelete: function(url) {
-    console.log(url);
-    window.alert("Sorry, club deletion has not yet been implemented.");
+  handleClubDelete: function(url, clubName) {
+    var confirmed = window.confirm(
+      "Are you sure you want to delete the club \"" + clubName + "\"? " +
+      "This action cannot be undone!"
+    );
+    if (!confirmed) {
+      return;
+    }
+    this.getTeachAPI().deleteClub(url, function(err) {
+      if (err) {
+        console.log(err);
+        window.alert("An error occurred! Please try again later.");
+      }
+      window.alert("Your club has been removed.");
+    });
   },
   handleClubEdit: function(url) {
     console.log(url);

--- a/components/map.jsx
+++ b/components/map.jsx
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var React = require('react');
 var mapboxId = process.env.MAPBOX_MAP_ID || 'alicoding.ldmhe4f3';
 var accessToken = process.env.MAPBOX_ACCESS_TOKEN || 'pk.eyJ1IjoiYWxpY29kaW5nIiwiYSI6Il90WlNFdE0ifQ.QGGdXGA_2QH-6ujyZE2oSg';
@@ -19,6 +18,22 @@ function geoJSONit(data) {
     }
   });
 }
+
+// Note that this class will always be rendered to static markup, so
+// it can't have any dynamic functionality.
+var MarkerPopup = React.createClass({
+  render: function() {
+    return (
+      <div>
+        <b>{this.props.title}<br/></b>
+        <i>{this.props.location}</i>
+        <br/>
+        <br/>
+        <p>{this.props.description}</p>
+      </div>
+    );
+  }
+});
 
 var Map = React.createClass({
   propTypes: {
@@ -43,25 +58,24 @@ var Map = React.createClass({
     this.map.fitBounds([[65, 0], [-65, 0]]);
 
     this.map.on('layeradd', function(e) {
+      var html;
       var marker = e.layer;
       var feature = marker.feature;
 
       // we have to check if this is a feature or marker-cluster.
       if (feature) {
-        var title = feature.properties.title;
-        var desc = feature.properties.title;
-        var location = feature.properties.location;
+        html = React.renderToStaticMarkup(React.createElement(MarkerPopup, {
+          title: feature.properties.title,
+          description: feature.properties.description,
+          location: feature.properties.location
+        }));
 
         marker.setIcon(L.icon({
           "iconUrl": "/img/map-marker.svg",
           "iconSize": [33, 33],
           "iconAnchor": [15, 15]
         }));
-        marker.bindPopup(
-          "<b>" + _.escape(title) + "<br></b><i>" +
-          _.escape(location) + "</i><br/><br/><p>" +
-          _.escape(desc) + "</p>"
-        );
+        marker.bindPopup(html);
       }
     });
     this.map.addLayer(this.markers);

--- a/components/map.jsx
+++ b/components/map.jsx
@@ -45,7 +45,8 @@ var MarkerPopup = React.createClass({
           </button>
           &nbsp;
           <button className="btn btn-default btn-xs"
-           data-club-action="delete" data-club-url={this.props.url}>
+           data-club-action="delete" data-club-url={this.props.url}
+           data-club-name={this.props.title}>
             <span className="glyphicon glyphicon-trash"></span> Remove
           </button>
         </div>
@@ -145,7 +146,7 @@ var Map = React.createClass({
     }
 
     if (action == 'delete') {
-      this.props.onDelete(url);
+      this.props.onDelete(url, targetEl.getAttribute('data-club-name'));
     } else if (action == 'edit') {
       this.props.onEdit(url);
     } else {

--- a/components/map.jsx
+++ b/components/map.jsx
@@ -117,6 +117,14 @@ var Map = React.createClass({
     }.bind(this));
     this.map.addLayer(this.markers);
     this.updateMap();
+
+    // We're doing this manually instead of via JSX markup to
+    // ensure that react-a11y doesn't complain about our lack of
+    // accessibility markup; such warnings are false positives, as
+    // we're only catching events that bubble up from the static
+    // marker popup button clicks to make *those* buttons usable,
+    // rather than offering any new kind of interactivity.
+    this.getDOMNode().addEventListener('click', this.handleClick);
   },
   updateMap: function() {
     if (this.geoJsonLayer) {
@@ -132,9 +140,8 @@ var Map = React.createClass({
     }
   },
   componentWillUnmount: function() {
-    if (this.map) {
-      this.map.remove();
-    }
+    this.getDOMNode().removeEventListener('click', this.handleClick);
+    this.map.remove();
   },
   handleClick: function(e) {
     var targetEl = e.target;
@@ -155,7 +162,7 @@ var Map = React.createClass({
   },
   render: function() {
     return (
-      <div className={this.props.className} onClick={this.handleClick}></div>
+      <div className={this.props.className}></div>
     )
   }
 });

--- a/components/map.jsx
+++ b/components/map.jsx
@@ -78,7 +78,7 @@ var Map = React.createClass({
     require('leaflet.markercluster');
     L.mapbox.accessToken = accessToken;
     this.map = L.mapbox.map(this.getDOMNode())
-      .setView([40.73, -50.011], 5)
+      .setView([0, 0], 2)
       .addLayer(L.mapbox.tileLayer(mapboxId));
     this.markers = new L.MarkerClusterGroup({
       iconCreateFunction: function(cluster) {
@@ -88,8 +88,6 @@ var Map = React.createClass({
         });
       }
     });
-
-    this.map.fitBounds([[65, 0], [-65, 0]]);
 
     this.map.on('layeradd', function(e) {
       var html;

--- a/components/map.jsx
+++ b/components/map.jsx
@@ -1,3 +1,4 @@
+var urlParse = require('url').parse;
 var React = require('react');
 var mapboxId = process.env.MAPBOX_MAP_ID || 'alicoding.ldmhe4f3';
 var accessToken = process.env.MAPBOX_ACCESS_TOKEN || 'pk.eyJ1IjoiYWxpY29kaW5nIiwiYSI6Il90WlNFdE0ifQ.QGGdXGA_2QH-6ujyZE2oSg';
@@ -11,6 +12,7 @@ function geoJSONit(data) {
       },
       "properties": {
         "description": i.description,
+        "website": i.website,
         "location": i.location,
         "title": i.name
       },
@@ -22,6 +24,9 @@ function geoJSONit(data) {
 // Note that this class will always be rendered to static markup, so
 // it can't have any dynamic functionality.
 var MarkerPopup = React.createClass({
+  getWebsiteDomain: function() {
+    return urlParse(this.props.website).hostname;
+  },
   render: function() {
     return (
       <div>
@@ -30,6 +35,9 @@ var MarkerPopup = React.createClass({
         <br/>
         <br/>
         <p>{this.props.description}</p>
+        <p><a href={this.props.website} target="_blank">
+          {this.getWebsiteDomain()}
+        </a></p>
       </div>
     );
   }
@@ -67,6 +75,7 @@ var Map = React.createClass({
         html = React.renderToStaticMarkup(React.createElement(MarkerPopup, {
           title: feature.properties.title,
           description: feature.properties.description,
+          website: feature.properties.website,
           location: feature.properties.location
         }));
 

--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -35,6 +35,7 @@ util.inherits(TeachAPI, EventEmitter);
 _.extend(TeachAPI.prototype, {
   logout: function() {
     delete this.storage[STORAGE_KEY];
+    this.emit('username:change', null);
     this.emit('logout');
   },
   getLoginInfo: function() {
@@ -74,6 +75,7 @@ _.extend(TeachAPI.prototype, {
           // TODO: Handle a thrown exception here.
           this.storage[STORAGE_KEY] = JSON.stringify(res.body);
 
+          this.emit('username:change', res.body.username);
           this.emit('login:success', res.body);
         }.bind(this));
     }.bind(this));

--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -99,6 +99,7 @@ _.extend(TeachAPI.prototype, {
         if (err) {
           return callback(err);
         }
+        this._clubs = res.body;
         this.emit('clubs:change', res.body);
         callback(null, res.body);
       }.bind(this));

--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -14,6 +14,7 @@ function TeachAPI(options) {
   this.storage = options.storage || (
     process.browser ? window.sessionStorage : {}
   );
+  this._clubs = [];
 }
 
 util.inherits(TeachAPI, EventEmitter);
@@ -74,15 +75,20 @@ _.extend(TeachAPI.prototype, {
 
     return req;
   },
-  getAllClubsData: function(callback) {
+  getClubs: function() {
+    return this._clubs;
+  },
+  updateClubs: function(callback) {
+    callback = callback || function () {};
     return this.request('get', '/api/clubs')
       .accept('json')
       .end(function(err, res) {
         if (err) {
           return callback(err);
         }
+        this.emit('clubs:change', res.body);
         callback(null, res.body);
-      });
+      }.bind(this));
   }
 });
 

--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -1,5 +1,6 @@
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
+var urlResolve = require('url').resolve;
 var _ = require('underscore');
 var request = require('superagent');
 
@@ -82,7 +83,7 @@ _.extend(TeachAPI.prototype, {
   },
   request: function(method, path) {
     var info = this.getLoginInfo();
-    var req = request(method, this.baseURL + path);
+    var req = request(method, urlResolve(this.baseURL, path));
 
     if (info && info.token) {
       req.set('Authorization', 'Token ' + info.token);
@@ -117,6 +118,18 @@ _.extend(TeachAPI.prototype, {
         }
         this.updateClubs();
         callback(null, res.body);
+      }.bind(this));
+  },
+  deleteClub: function(url, callback) {
+    callback = callback || function () {};
+    return this.request('delete', url)
+      .accept('json')
+      .end(function(err, res) {
+        if (err) {
+          return callback(err);
+        }
+        this.updateClubs();
+        callback(null);
       }.bind(this));
   }
 });

--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -5,8 +5,21 @@ var request = require('superagent');
 
 var STORAGE_KEY = 'TEACH_API_LOGIN_INFO';
 
+function autobind(obj) {
+  var prototypes = [].slice.call(arguments, 1);
+  prototypes.forEach(function(prototype) {
+    Object.keys(prototype).filter(function(propName) {
+      return typeof obj[propName] == 'function';
+    }).forEach(function(methodName) {
+      obj[methodName] = obj[methodName].bind(obj);
+    });
+  });
+}
+
 function TeachAPI(options) {
   options = options || {};
+
+  autobind(this, TeachAPI.prototype, EventEmitter.prototype);
 
   this.baseURL = (options.baseURL ||
                   process.env.TEACH_API_URL ||
@@ -80,13 +93,26 @@ _.extend(TeachAPI.prototype, {
   },
   updateClubs: function(callback) {
     callback = callback || function () {};
-    return this.request('get', '/api/clubs')
+    return this.request('get', '/api/clubs/')
       .accept('json')
       .end(function(err, res) {
         if (err) {
           return callback(err);
         }
         this.emit('clubs:change', res.body);
+        callback(null, res.body);
+      }.bind(this));
+  },
+  addClub: function(club, callback) {
+    callback = callback || function () {};
+    return this.request('post', '/api/clubs/')
+      .send(club)
+      .accept('json')
+      .end(function(err, res) {
+        if (err) {
+          return callback(err);
+        }
+        this.updateClubs();
         callback(null, res.body);
       }.bind(this));
   }

--- a/mixins/teach-api-client.js
+++ b/mixins/teach-api-client.js
@@ -25,6 +25,11 @@ module.exports = {
   getTeachAPI: function() {
     return this.context.teachAPI;
   },
+  // It seems the forceUpdate() method is not auto-bound to a component,
+  // so we'll make our own wrapper here.
+  _autoboundForceUpdate: function() {
+    this.forceUpdate();
+  },
   componentDidMount: function() {
     var displayName = this.constructor.displayName;
     var events = this.constructor.teachAPIEvents;
@@ -33,6 +38,10 @@ module.exports = {
       Object.keys(events).forEach(function(event) {
         var methodName = events[event];
         var method = this[methodName];
+
+        if (methodName == 'forceUpdate') {
+          method = this._autoboundForceUpdate;
+        }
         if (typeof(method) != 'function') {
           console.warn('method ' + displayName + '::' + methodName +
                        ' does not exist');
@@ -49,6 +58,10 @@ module.exports = {
       Object.keys(events).forEach(function(event) {
         var methodName = events[event];
         var method = this[methodName];
+
+        if (methodName == 'forceUpdate') {
+          method = this._autoboundForceUpdate;
+        }
         if (typeof(method) == 'function') {
           this.context.teachAPI.removeListener(event, method);
         }

--- a/test/browser/clubs-page.test.jsx
+++ b/test/browser/clubs-page.test.jsx
@@ -1,0 +1,32 @@
+var should = require('should');
+var React =require('react/addons');
+var TestUtils = React.addons.TestUtils;
+
+var StubTeachAPI = require('./stub-teach-api');
+var stubContext = require('./stub-context.jsx');
+var ClubsPage = require('../../components/clubs-page.jsx');
+
+describe("ClubsPage", function() {
+  var clubsPage, teachAPI, xhr;
+
+  beforeEach(function() {
+    // The map widget on the clubs page will try to use XHR. We want to
+    // fake that so that network issues don't cause this test to fail,
+    // and so that PhantomJS doesn't hang on us.
+    xhr = sinon.useFakeXMLHttpRequest();
+
+    teachAPI = new StubTeachAPI();
+    clubsPage = stubContext.render(ClubsPage, {}, {
+      teachAPI: teachAPI
+    });
+  });
+
+  afterEach(function() {
+    stubContext.unmount(clubsPage);
+    xhr.restore();
+  });
+
+  it('triggers clubs update when mounted', function() {
+    teachAPI.updateClubs.callCount.should.equal(1);
+  });
+});

--- a/test/browser/main.js
+++ b/test/browser/main.js
@@ -4,5 +4,6 @@ require('./config.test.js');
 require('./sidebar.test.jsx');
 require('./imagetag.test.jsx');
 require('./teach-api.test.js');
+require('./teach-api-client.test.jsx');
 require('./login.test.jsx');
 require('./modal.test.jsx');

--- a/test/browser/main.js
+++ b/test/browser/main.js
@@ -8,3 +8,4 @@ require('./teach-api-client.test.jsx');
 require('./login.test.jsx');
 require('./modal.test.jsx');
 require('./modal-manager.test.js');
+require('./clubs-page.test.jsx');

--- a/test/browser/main.js
+++ b/test/browser/main.js
@@ -7,3 +7,4 @@ require('./teach-api.test.js');
 require('./teach-api-client.test.jsx');
 require('./login.test.jsx');
 require('./modal.test.jsx');
+require('./modal-manager.test.js');

--- a/test/browser/modal-manager.test.js
+++ b/test/browser/modal-manager.test.js
@@ -1,0 +1,25 @@
+var _ = require('underscore');
+
+var ModalManagerMixin = require('../../mixins/modal-manager');
+
+function makeFakeComponentWithContext(fakeContext) {
+  return _.extend({ context: fakeContext }, ModalManagerMixin);
+}
+
+describe('ModalManagerMixin', function() {
+  it('should provide showModal() method', function(done) {
+    makeFakeComponentWithContext({
+      showModal: function(modalClass, modalProps) {
+        modalClass.should.eql("class");
+        modalProps.should.eql("props");
+        done();
+      }
+    }).showModal("class", "props");
+  });
+
+  it('should provide hideModal() method', function(done) {
+    makeFakeComponentWithContext({
+      hideModal: function() { done(); }
+    }).hideModal();
+  });
+});

--- a/test/browser/stub-context.jsx
+++ b/test/browser/stub-context.jsx
@@ -24,6 +24,8 @@ var stubContext = function(Component, props, stubs) {
       getCurrentParams: func,
       getCurrentQuery: func,
       isActive: func,
+      showModal: func,
+      hideModal: func,
       teachAPI: React.PropTypes.object
     },
 
@@ -40,6 +42,8 @@ var stubContext = function(Component, props, stubs) {
         getCurrentParams: noop,
         getCurrentQuery: noop,
         isActive: noop,
+        showModal: noop,
+        hideModal: noop,
         teachAPI: new StubTeachAPI()
       }, stubs);
     },

--- a/test/browser/stub-teach-api.js
+++ b/test/browser/stub-teach-api.js
@@ -7,7 +7,11 @@ function StubTeachAPI() {
   teachAPI.logout = sinon.spy();
   teachAPI.startLogin = sinon.spy();
   teachAPI.getUsername = sinon.stub();
-  teachAPI.getAllClubsData = sinon.spy();
+  teachAPI.getClubs = sinon.stub();
+  teachAPI.updateClubs = sinon.spy();
+
+  teachAPI.getUsername.returns(null);
+  teachAPI.getClubs.returns([]);
 
   return teachAPI;
 }

--- a/test/browser/teach-api-client.test.jsx
+++ b/test/browser/teach-api-client.test.jsx
@@ -1,0 +1,78 @@
+var EventEmitter = require('events').EventEmitter;
+var React = require('react');
+
+var StubTeachAPI = require('./stub-teach-api.js');
+var stubContext = require('./stub-context.jsx');
+var TeachApiClientMixin = require('../../mixins/teach-api-client');
+
+describe('TeachApiClientMixin', function() {
+  var teachAPI, component;
+  var MyComponent = React.createClass({
+    mixins: [TeachApiClientMixin],
+    statics: {
+      teachAPIEvents: {
+        'blah': 'handleBlah',
+        'username:change': 'forceUpdate'
+      }
+    },
+    getInitialState: function() {
+      return {blah: 0};
+    },
+    handleBlah: function() {
+      this.setState({blah: this.state.blah + 1});
+    },
+    render: function() {
+      return <div>{this.getTeachAPI().getUsername()}</div>;
+    }
+  });
+
+  beforeEach(function() {
+    teachAPI = new StubTeachAPI();
+  });
+
+  afterEach(function() {
+    if (component) {
+      stubContext.unmount(component);
+    }
+  });
+
+  it('should provide access to Teach API', function() {
+    teachAPI.getUsername.returns("foo");
+    component = stubContext.render(MyComponent, {}, {
+      teachAPI: teachAPI
+    });
+    component.getDOMNode().textContent.should.eql("foo");
+  });
+
+  it('should bind to events that call forceUpdate', function() {
+    component = stubContext.render(MyComponent, {}, {
+      teachAPI: teachAPI
+    });
+    teachAPI.getUsername.returns("bar");
+    component.getDOMNode().textContent.should.not.eql("bar");
+    teachAPI.emit('username:change');
+    component.getDOMNode().textContent.should.eql("bar");
+  });
+
+  it('should bind to events that call methods', function() {
+    component = stubContext.render(MyComponent, {}, {
+      teachAPI: teachAPI
+    });
+    component.state.blah.should.equal(0);
+    teachAPI.emit('blah');
+    component.state.blah.should.equal(1);
+  });
+
+  it('should unbind event listeners when unmounting', function() {
+    component = stubContext.render(MyComponent, {}, {
+      teachAPI: teachAPI
+    });
+    EventEmitter.listenerCount(teachAPI, 'username:change').should.equal(1);
+
+    stubContext.unmount(component);
+    component = null;
+
+    EventEmitter.listenerCount(teachAPI, 'username:change').should.equal(0);
+  });
+
+});

--- a/test/browser/teach-api.test.js
+++ b/test/browser/teach-api.test.js
@@ -19,6 +19,16 @@ describe('TeachAPI', function() {
     xhr.restore();
   });
 
+  it('emits username:change event on logout', function(done) {
+    var api = new TeachAPI({storage: storage});
+
+    api.on('username:change', function(username) {
+      should(username).equal(null);
+      done();
+    });
+    api.logout();
+  });
+
   it('clears storage on logout', function(done) {
     var api = new TeachAPI({storage: storage});
 
@@ -287,7 +297,8 @@ describe('TeachAPI', function() {
       }, 'invalid assertion or email');
     });
 
-    it('stores login info and emits event upon success', function(done) {
+    it('stores login info and emits events upon success', function(done) {
+      var usernameEventEmitted = false;
       var api = new TeachAPI({storage: storage});
       var loginInfo = {
         'username': 'foo',
@@ -297,10 +308,15 @@ describe('TeachAPI', function() {
       api.startLogin();
       personaCb('hi');
 
+      api.on('username:change', function(username) {
+        username.should.eql('foo');
+        usernameEventEmitted = true;
+      });
       api.on('login:success', function(info) {
         info.should.eql(loginInfo);
         JSON.parse(storage['TEACH_API_LOGIN_INFO'])
           .should.eql(loginInfo);
+        usernameEventEmitted.should.be.true;
         done();
       });
 

--- a/test/browser/teach-api.test.js
+++ b/test/browser/teach-api.test.js
@@ -91,7 +91,7 @@ describe('TeachAPI', function() {
     should(api.getUsername()).equal(null);
   });
 
-  describe('getAllClubsData()', function() {
+  describe('updateClubs()', function() {
     var api;
 
     beforeEach(function() {
@@ -102,14 +102,14 @@ describe('TeachAPI', function() {
     });
 
     it('accesses /api/clubs', function() {
-      api.getAllClubsData(function() {});
+      api.updateClubs();
       requests.length.should.equal(1);
       requests[0].method.should.eql('get');
       requests[0].url.should.eql('http://example.org/api/clubs');
     });
 
     it('returns parsed JSON on success', function(done) {
-      api.getAllClubsData(function(err, data) {
+      api.updateClubs(function(err, data) {
         should(err).equal(null);
         data.should.eql([{name: "blah"}]);
         done();
@@ -120,7 +120,7 @@ describe('TeachAPI', function() {
     });
 
     it('returns an error on failure', function(done) {
-      api.getAllClubsData(function(err, data) {
+      api.updateClubs(function(err, data) {
         err.message.should.eql("Internal Server Error");
         done();
       });

--- a/test/browser/teach-api.test.js
+++ b/test/browser/teach-api.test.js
@@ -101,11 +101,11 @@ describe('TeachAPI', function() {
       });
     });
 
-    it('accesses /api/clubs', function() {
+    it('accesses /api/clubs/', function() {
       api.updateClubs();
       requests.length.should.equal(1);
       requests[0].method.should.eql('get');
-      requests[0].url.should.eql('http://example.org/api/clubs');
+      requests[0].url.should.eql('http://example.org/api/clubs/');
     });
 
     it('returns parsed JSON on success', function(done) {
@@ -167,7 +167,10 @@ describe('TeachAPI', function() {
     });
 
     it('sends assertion to Teach API server', function() {
-      var api = new TeachAPI({storage: storage});
+      var api = new TeachAPI({
+        baseURL: 'http://example.org',
+        storage: storage
+      });
 
       api.startLogin();
       personaCb('hi');
@@ -176,7 +179,7 @@ describe('TeachAPI', function() {
 
       var r = requests[0];
 
-      r.url.should.eql('https://teach-api.herokuapp.com/auth/persona');
+      r.url.should.eql('http://example.org/auth/persona');
       r.requestHeaders.should.eql({
         'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8'
       });

--- a/test/browser/teach-api.test.js
+++ b/test/browser/teach-api.test.js
@@ -206,6 +206,39 @@ describe('TeachAPI', function() {
     });
   });
 
+  describe('deleteClub()', function() {
+    var api;
+
+    beforeEach(function() {
+      api = new TeachAPI({storage: storage});
+    });
+
+    it('accesses the given URL', function() {
+      api.deleteClub('http://myserver/clubs/1');
+      requests.length.should.equal(1);
+      requests[0].method.should.eql('delete');
+      requests[0].url.should.eql('http://myserver/clubs/1');
+    });
+
+    it('returns no error on success', function(done) {
+      api.updateClubs = sinon.spy();
+      api.deleteClub('http://foo', function(err) {
+        should(err).equal(null);
+        done();
+      });
+      requests[0].respond(204);
+      api.updateClubs.callCount.should.equal(1);
+    });
+
+    it('returns an error on failure', function(done) {
+      api.deleteClub('http://foo', function(err, data) {
+        err.message.should.eql("Internal Server Error");
+        done();
+      });
+      requests[0].respond(500);
+    });
+  });
+
   describe('startLogin()', function() {
     var personaCb;
 


### PR DESCRIPTION
This implements rudimentary club creation and deletion.

By "rudimentary" I mean that a number of dialogs have been stubbed out with `window.alert()` but communication with the Teach API is done properly and only the owner (creator) of a club has the ability to delete it.

Other notes:

* In general I am trying to make as few components directly use the teach API as possible. so that components are passed in information via `props` and use callbacks etc to delegate state change to their parents. I *think* this is a [best practice](http://facebook.github.io/react/docs/two-way-binding-helpers.html) in React and makes the operation of our app more understandable.
* As such, the `Map` component no longer directly accesses the Teach API, and is instead given a list of clubs by its parent.
* Because Leaflet renders marker popups as static HTML, we can't make those React components. So we need to do some annoying things to integrate UI in the popups.

TODOs:
- [ ] I should really move the `autobind` function out of `teach-api.js` and into its own module, and add tests for it.
- [ ] Even though the UI is in a lot of flux, I should probably at least add a few tests for the Clubs page to ensure that the modals work.
- [ ] Obviously most/all of the `window.alert`s need to be converted to more user-friendly interactions, many of which have already been mocked up by our designers. (But I think there may be some edge cases that haven't been mocked up!)