### PR TITLE
Add autocomplete to location field in add/edit clubs dialogs.

### DIFF
--- a/components/map.jsx
+++ b/components/map.jsx
@@ -73,9 +73,16 @@ var MarkerPopup = React.createClass({
 
 var Map = React.createClass({
   propTypes: {
-    className: React.PropTypes.string.isRequired
+    className: React.PropTypes.string.isRequired,
+    clubs: React.PropTypes.array.isRequired,
+    username: React.PropTypes.string,
+    onDelete: React.PropTypes.func.isRequired,
+    onEdit: React.PropTypes.func.isRequired
   },
   statics: {
+    setAccessToken: function(value) {
+      accessToken = value;
+    },
     getAutocompleteOptions: function(input, callback) {
       var url = 'http://api.tiles.mapbox.com/v4/geocode/mapbox.places/' +
                 encodeURIComponent(input) +

--- a/less/components/modal.less
+++ b/less/components/modal.less
@@ -40,14 +40,22 @@
     label + p {
       margin-bottom: 0;
     }
-    input, textarea {
-      width: 100%;
-      padding: 1rem;
+    input, textarea, .Select-control {
       margin-top: 1rem;
       font-weight: 400;
       font-style: 1.4rem;
+    }
+    input, textarea {
+      width: 100%;
+      padding: 1rem;
       border: 1px solid #D2D2D2;
       box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.1);
+    }
+    .Select-input input {
+      padding: 0;
+      margin-top: 0;
+      border: none;
+      box-shadow: none;
     }
     fieldset {
       margin-bottom: 2rem;

--- a/less/components/modal.less
+++ b/less/components/modal.less
@@ -51,6 +51,9 @@
       border: 1px solid #D2D2D2;
       box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.1);
     }
+    .Select.is-disabled .Select-control {
+      background: rgb(235, 235, 228);
+    }
     .Select-input input {
       padding: 0;
       margin-top: 0;

--- a/less/index.less
+++ b/less/index.less
@@ -3,3 +3,4 @@
 @import "common";
 @import "components/index";
 @import "pages/index";
+@import "../node_modules/react-select/less/default.less";

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "^0.12.2",
     "react-a11y": "0.0.6",
     "react-router": "^0.12.4",
+    "react-select": "^0.4.2",
     "should": "^5.1.0",
     "superagent": "^1.1.0",
     "underscore": "^1.8.2",

--- a/pages/clubs.jsx
+++ b/pages/clubs.jsx
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var React = require('react/addons');
 var Router = require('react-router');
 var Link = Router.Link;
+var Select = require('react-select');
 
 var Page = require('../components/page.jsx');
 var HeroUnit = require('../components/hero-unit.jsx');
@@ -107,11 +108,14 @@ var ModalAddOrChangeYourClub = React.createClass({
       name: '',
       website: '',
       description: '',
-      location: ''
+      location: '',
+      latitude: null,
+      longitude: null
     };
     if (this.props.club) {
       _.extend(clubState, _.pick(this.props.club,
-        'name', 'website', 'description', 'location'
+        'name', 'website', 'description', 'location', 'latitude',
+        'longitude'
       ));
     }
     return _.extend(clubState, {
@@ -126,24 +130,36 @@ var ModalAddOrChangeYourClub = React.createClass({
   handleUsernameChange: function(username) {
     this.setState({step: this.getStepForAuthState(!!username)});
   },
+  handleLocationChange: function(newValue) {
+    try {
+      newValue = JSON.parse(newValue);
+    } catch (e) {
+      newValue = {
+        location: '',
+        latitude: null,
+        longitude: null
+      };
+    }
+    this.setState(newValue);
+  },
   handleSubmit: function(e) {
     var teachAPI = this.getTeachAPI();
     var clubState = _.pick(this.state,
-      'name', 'website', 'description', 'location'
+      'name', 'website', 'description', 'location', 'latitude', 'longitude'
     );
-
     e.preventDefault();
+
+    if (!this.state.location) {
+      window.alert("Please provide a location for your club.");
+      return;
+    }
+
     this.setState({
       step: this.STEP_WAIT_FOR_NETWORK,
       networkError: false
     });
     if (this.props.club) {
       clubState = _.extend({}, this.props.club, clubState);
-
-      // For now, let's always force re-geocoding.
-      clubState.latitude = null;
-      clubState.longitude = null;
-
       teachAPI.changeClub(clubState, this.handleNetworkResult);
     } else {
       teachAPI.addClub(clubState, this.handleNetworkResult);
@@ -205,10 +221,29 @@ var ModalAddOrChangeYourClub = React.createClass({
             </fieldset>
             <fieldset>
               <label>Where does it take place?</label>
-              <input type="text" placeholder="Type in a city or a country"
+              <Select
                disabled={isFormDisabled}
-               required
-               valueLink={this.linkState('location')} />
+               placeholder="Type in a city or a country"
+
+               // We need to provide undefined instead of an empty
+               // string in order for the placeholder text to show.
+               value={this.state.location || undefined}
+
+               // Even though we are not using multi={true}, the Select
+               // component seems to split on the default multi delimiter,
+               // which is ",". Since that delimiter appears in every
+               // location string (e.g. "Brooklyn, NY US"), we want to
+               // set it to something that never appears.
+               delimiter="|"
+
+               // We do not want any suggestions auto-loaded until
+               // the user starts typing. Aside from that, though, tests
+               // fail w/ a React Invariant Violation if we do not
+               // disable this feature.
+               autoload={false}
+
+               asyncOptions={Map.getAutocompleteOptions}
+               onChange={this.handleLocationChange} />
             </fieldset>
             <fieldset>
               <label>What is your Club&lsquo;s website?</label>

--- a/test/browser/clubs-page.test.jsx
+++ b/test/browser/clubs-page.test.jsx
@@ -18,7 +18,7 @@ function ensureFormFieldsDisabledValue(component, isDisabled) {
       tag
     ).forEach(function(component) {
       found++;
-      component.props.disabled.should.equal(isDisabled);
+      component.getDOMNode().disabled.should.equal(isDisabled);
     });
   });
 
@@ -151,7 +151,9 @@ describe("ClubsPage.ModalAddOrChangeYourClub", function() {
           name: 'blorpy',
           location: 'chicago',
           website: 'http://example.org',
-          description: 'this is my club'
+          description: 'this is my club',
+          latitude: null,
+          longitude: null
         });
       });
 
@@ -256,8 +258,8 @@ describe("ClubsPage.ModalAddOrChangeYourClub", function() {
           description: 'my club',
           location: 'somewhere',
           website: 'http://boop',
-          latitude: null,
-          longitude: null
+          latitude: 42,
+          longitude: 8
         });
       });
 

--- a/test/browser/clubs-page.test.jsx
+++ b/test/browser/clubs-page.test.jsx
@@ -125,6 +125,24 @@ describe("ClubsPage.ModalAddOrChangeYourClub", function() {
       ensureFormFieldsDisabledValue(modal, false);
     });
 
+    it("handles location changes containing JSON", function() {
+      modal.handleLocationChange(JSON.stringify({
+        location: 'foo',
+        longitude: 35,
+        latitude: 24
+      }));
+      modal.state.location.should.eql('foo');
+      modal.state.longitude.should.equal(35);
+      modal.state.latitude.should.equal(24);
+    });
+
+    it("handles location changes not containing JSON", function() {
+      modal.handleLocationChange('');
+      modal.state.location.should.eql('');
+      should(modal.state.longitude).equal(null);
+      should(modal.state.latitude).equal(null);
+    });
+
     describe("when form is submitted", function() {
       var addClubCall, form;
 

--- a/test/browser/main.js
+++ b/test/browser/main.js
@@ -9,3 +9,4 @@ require('./login.test.jsx');
 require('./modal.test.jsx');
 require('./modal-manager.test.js');
 require('./clubs-page.test.jsx');
+require('./map.test.jsx');

--- a/test/browser/map.test.jsx
+++ b/test/browser/map.test.jsx
@@ -1,0 +1,102 @@
+var should = require('should');
+var sinon = window.sinon;
+var React =require('react/addons');
+var TestUtils = React.addons.TestUtils;
+
+var Map = require('../../components/map.jsx');
+var stubContext = require('./stub-context.jsx');
+
+describe("Map", function() {
+  var map, xhr;
+
+  beforeEach(function() {
+    // The map widget will try to use XHR. We want to
+    // fake that so that network issues don't cause this test to fail,
+    // and so that PhantomJS doesn't hang on us.
+    xhr = sinon.useFakeXMLHttpRequest();
+    map = stubContext.render(Map, {
+      className: 'foo',
+      clubs: [],
+      username: null,
+      onDelete: sinon.spy(),
+      onEdit: sinon.spy()
+    }, {});
+  });
+
+  afterEach(function() {
+    stubContext.unmount(map);
+    xhr.restore();
+  });
+
+  it("should render", function() {
+    map.getDOMNode().className.should.match(/foo/);
+  });
+});
+
+describe("Map.getAutocompleteOptions()", function() {
+  var xhr, requests;
+
+  beforeEach(function() {
+    requests = [];
+    Map.setAccessToken('mytoken');
+    sinon.stub(process, 'nextTick');
+    xhr = sinon.useFakeXMLHttpRequest();
+    xhr.onCreate = function(xhr) {
+      requests.push(xhr);
+    };
+  });
+
+  afterEach(function() {
+    xhr.restore();
+    process.nextTick.restore();
+  });
+
+  it("should return empty results on empty input", function(done) {
+    Map.getAutocompleteOptions('', function(err, info) {
+      should(err).equal(null);
+      info.options.should.eql([]);
+      done();
+    });
+    process.nextTick.callCount.should.eql(1);
+    process.nextTick.getCall(0).args[0]();
+  });
+
+  it("should query mapbox for results", function() {
+    Map.getAutocompleteOptions('blah', function() {});
+    requests.length.should.eql(1);
+    requests[0].method.should.eql('get');
+    requests[0].url.should.eql('http://api.tiles.mapbox.com/v4/geocode/' +
+                               'mapbox.places/blah.json?' +
+                               'access_token=mytoken');
+  });
+
+  it("should pass errors back to callback", function(done) {
+    Map.getAutocompleteOptions('blah', function(err) {
+      err.message.should.eql("Internal Server Error");
+      done();
+    });
+    requests[0].respond(500);
+  });
+
+  it("should pass results back to callback", function(done) {
+    Map.getAutocompleteOptions('blah', function(err, info) {
+      should(err).equal(null);
+      info.options.length.should.equal(1);
+      JSON.parse(info.options[0].value).should.eql({
+        location: "Somewhere",
+        latitude: 2,
+        longitude: 1
+      });
+      info.options[0].label.should.eql("Somewhere");
+      done();
+    });
+    requests[0].respond(200, {
+      'Content-Type': 'application/vnd.geo+json'
+    }, JSON.stringify({
+      features: [{
+        place_name: "Somewhere",
+        center: [1, 2]
+      }]
+    }));
+  });
+});


### PR DESCRIPTION
This fixes #353.

TODOs:

- [x] Add tests.
- [x] The widget is technically disabled when the form is being submitted, but it isn't styled to *look* disabled, so we should change this.
- [ ] We're using `react-select`'s default CSS, which is subtly different from our CSS. Might want to get @vazquez to optimize it (we can file this as a separate issue if needed).
- [ ] There isn't an easy way to set `required` on the input field inside the `Select` component, so right now we just do a `window.alert` telling the user to fill out the location field. This is suboptimal, but we can file this as a separate issue if needed.
