### PR TITLE
Use Router.RefreshLocation instead of Router.HashLocation.

### DIFF
--- a/lib/main.jsx
+++ b/lib/main.jsx
@@ -11,9 +11,7 @@ function startRunningSite() {
   if (config.ENABLE_PUSHSTATE) {
     routes.run(Router.HistoryLocation, pageHolder);
   } else {
-    if (!window.location.hash.slice(1))
-      window.location.hash = '#' + url;
-    routes.run(Router.HashLocation, pageHolder);
+    routes.run(Router.RefreshLocation, pageHolder);
   }
 }
 


### PR DESCRIPTION
This fixes #232. I also know that we could just pass `Router.HistoryLocation` to `Router.run()` and let it gracefully degrade to `Router.RefreshLocation` on its own, but that would make it harder for us to manually test.