### PR TITLE
Scroll map into view when taking users to their club.

### DIFF
--- a/pages/clubs.jsx
+++ b/pages/clubs.jsx
@@ -431,6 +431,7 @@ var ClubsPage = React.createClass({
     this.showModal(ModalLearnMore);
   },
   handleAddClubSuccess: function(club) {
+    this.refs.map.getDOMNode().scrollIntoView();
     this.refs.map.focusOnClub(club);
   },
   handleClubDelete: function(url, clubName) {


### PR DESCRIPTION
This fixes #382.

I originally tried using [`smooth-scroll`](https://github.com/cferdinandi/smooth-scroll) to do this, but ran into weird issues, and also got the heebie-jeebies about it conflicting with React (it seems to use `history.pushState`, which is weird to me), so I just resorted to `Element.scrollIntoView()` for now. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView), it's supported by all browsers as far back as IE 6, so we should be safe.