### PR TITLE
Remove linkTo on PageEndCTA in clubs.jsx

### DIFF
--- a/pages/clubs.jsx
+++ b/pages/clubs.jsx
@@ -150,7 +150,7 @@ var BottomCTA = React.createClass({
     return(
       <div className="row">
         <div className="col-sm-offset-2 col-sm-8 col-md-offset-2 col-md-8 col-lg-offset-2 col-lg-8">
-          <PageEndCTA linkTo={this.props.ctaLink}>
+          <PageEndCTA>
             <div>
               <img className="divider" src="/img/clubs-line-divider.svg" alt="line divider" />
               <p>Do you meet regularly with a group of learners to increase web literacy skills?</p>


### PR DESCRIPTION
The PageEndCTA component doesn't seem to take a `linkTo` prop, nor does the `BottomCTA` seem to take a `ctaLink` prop. I didn't write the original code though, so I'm submitting this PR for review in case I'm mistaken.