### PR TITLE
Remove propTypes.children from PageEndCTA

### DIFF
--- a/components/page-end-cta.jsx
+++ b/components/page-end-cta.jsx
@@ -3,9 +3,6 @@ var Router = require('react-router');
 var Link = Router.Link;
 
 var PageEndCTA = React.createClass({
-  propTypes: {
-    children: React.PropTypes.object.isRequired
-  },
   render: function() {
     return (
       <div className="page-end-cta">


### PR DESCRIPTION
It's possible for `props.children` to be an array instead of an object, e.g. if multiple elements w/ no parent are provided; react currently complains about this w/ `propTypes` defined. I don't think there's a way to specify that a prop contain either an object *or* an array, so we should probably just remove it from `propTypes`.