### PR TITLE
Use code splitting to lazy-load mapbox/leaflet

### DIFF
--- a/components/map.jsx
+++ b/components/map.jsx
@@ -115,7 +115,8 @@ var Map = React.createClass({
     clubs: React.PropTypes.array.isRequired,
     username: React.PropTypes.string,
     onDelete: React.PropTypes.func.isRequired,
-    onEdit: React.PropTypes.func.isRequired
+    onEdit: React.PropTypes.func.isRequired,
+    onReady: React.PropTypes.func
   },
   statics: {
     MarkerPopup: MarkerPopup,
@@ -161,8 +162,18 @@ var Map = React.createClass({
     }
   },
   componentDidMount: function() {
-    require('mapbox.js'); // this will automatically attach to Window object.
-    require('leaflet.markercluster');
+    var self = this;
+    require([
+      // These will automatically attach to the window object.
+      'mapbox.js',
+      'leaflet.markercluster'
+    ], function() {
+      if (self.isMounted()) {
+        self.handleDependenciesLoaded();
+      }
+    });
+  },
+  handleDependenciesLoaded: function() {
     L.mapbox.accessToken = accessToken;
     this.map = L.mapbox.map(this.refs.map.getDOMNode())
       .setView([0, 0], 2)
@@ -216,6 +227,9 @@ var Map = React.createClass({
     // marker popup button clicks to make *those* buttons usable,
     // rather than offering any new kind of interactivity.
     this.getDOMNode().addEventListener('click', this.handleClick);
+    if (this.props.onReady) {
+      this.props.onReady();
+    }
   },
   getInitialState: function() {
     return {
@@ -237,7 +251,9 @@ var Map = React.createClass({
   },
   componentWillUnmount: function() {
     this.getDOMNode().removeEventListener('click', this.handleClick);
-    this.map.remove();
+    if (this.map) {
+      this.map.remove();
+    }
   },
   handleClick: function(e) {
     var targetEl = e.target;

--- a/components/map.jsx
+++ b/components/map.jsx
@@ -2,6 +2,14 @@ var urlParse = require('url').parse;
 var React = require('react');
 var request = require('superagent');
 
+var config = require('../lib/config');
+
+var DEFAULT_STYLESHEETS = config.IN_TEST_SUITE ? [] : [
+  'https://api.tiles.mapbox.com/mapbox.js/v2.1.5/mapbox.css',
+  'https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css',
+  'https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css'
+];
+
 var mapboxId = process.env.MAPBOX_MAP_ID || 'alicoding.ldmhe4f3';
 var accessToken = process.env.MAPBOX_ACCESS_TOKEN || 'pk.eyJ1IjoiYWxpY29kaW5nIiwiYSI6Il90WlNFdE0ifQ.QGGdXGA_2QH-6ujyZE2oSg';
 
@@ -116,6 +124,7 @@ var Map = React.createClass({
     username: React.PropTypes.string,
     onDelete: React.PropTypes.func.isRequired,
     onEdit: React.PropTypes.func.isRequired,
+    stylesheets: React.PropTypes.array,
     onReady: React.PropTypes.func
   },
   statics: {
@@ -161,8 +170,27 @@ var Map = React.createClass({
         });
     }
   },
+  getDefaultProps: function() {
+    return {
+      stylesheets: DEFAULT_STYLESHEETS
+    };
+  },
+  installStylesheets: function() {
+    var head = document.getElementsByTagName('head')[0];
+    this.props.stylesheets.forEach(function(url) {
+      var link = document.querySelector('link[href="' + url + '"]');
+      if (link) {
+        return;
+      }
+      link = document.createElement('link');
+      link.setAttribute('href', url);
+      link.setAttribute('rel', 'stylesheet');
+      head.appendChild(link);
+    });
+  },
   componentDidMount: function() {
     var self = this;
+    this.installStylesheets();
     require([
       // These will automatically attach to the window object.
       'mapbox.js',

--- a/components/map.jsx
+++ b/components/map.jsx
@@ -177,12 +177,10 @@ var Map = React.createClass({
   },
   installStylesheets: function() {
     var head = document.getElementsByTagName('head')[0];
-    this.props.stylesheets.forEach(function(url) {
-      var link = document.querySelector('link[href="' + url + '"]');
-      if (link) {
-        return;
-      }
-      link = document.createElement('link');
+    this.props.stylesheets.filter(function(url) {
+      return !document.querySelector('link[href="' + url + '"]');
+    }).forEach(function(url) {
+      var link = document.createElement('link');
       link.setAttribute('href', url);
       link.setAttribute('rel', 'stylesheet');
       head.appendChild(link);

--- a/lib/index-static.jsx
+++ b/lib/index-static.jsx
@@ -30,7 +30,6 @@ function generateWithPageHTML(url, options, pageHTML) {
         <div id="page-holder" dangerouslySetInnerHTML={{
           __html: pageHTML
         }}></div>
-        <script src='https://api.tiles.mapbox.com/mapbox.js/v2.1.5/mapbox.js'></script>
         <script src="/commons.bundle.js"></script>
         <script src="/app.bundle.js"></script>
         <script src="https://mozorg.cdn.mozilla.net/tabzilla/tabzilla.js"></script>

--- a/lib/index-static.jsx
+++ b/lib/index-static.jsx
@@ -17,9 +17,6 @@ function generateWithPageHTML(url, options, pageHTML) {
         <link rel="stylesheet" href="/vendor/bootstrap/css/bootstrap.min.css"/>
         <link href="https://mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet" />
         <link rel="stylesheet" href={'/' + exports.CSS_FILENAME}/>
-        <link href="https://api.tiles.mapbox.com/mapbox.js/v2.1.5/mapbox.css" rel="stylesheet" />
-        <link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-        <link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
         <script dangerouslySetInnerHTML={{
           __html: "document.documentElement.setAttribute('class', '');"
         }}></script>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "bootstrap": "^3.3.4",
     "es5-shim": "^4.1.0",
+    "express": "^4.12.3",
     "gulp": "^3.8.11",
     "gulp-autoprefixer": "^2.1.0",
     "gulp-gzip": "^1.0.0",
@@ -49,7 +50,7 @@
   "devDependencies": {},
   "scripts": {
     "test": "gulp smoketest && mocha test/*.test.js && npm run browsertest && gulp lint-test",
-    "browsertest": "mocha-phantomjs -s loadImages=false dist/test/index.html",
+    "browsertest": "node test/browser/run-in-phantom.js",
     "smoketest": "gulp smoketest",
     "s3": "gulp s3",
     "build": "gulp",

--- a/test/browser/map.test.jsx
+++ b/test/browser/map.test.jsx
@@ -31,7 +31,7 @@ var SAMPLE_BAR_CLUB = {
 describe("Map", function() {
   var map, xhr;
 
-  beforeEach(function() {
+  beforeEach(function(done) {
     // The map widget will try to use XHR. We want to
     // fake that so that network issues don't cause this test to fail,
     // and so that PhantomJS doesn't hang on us.
@@ -41,7 +41,10 @@ describe("Map", function() {
       clubs: [],
       username: null,
       onDelete: sinon.spy(),
-      onEdit: sinon.spy()
+      onEdit: sinon.spy(),
+      onReady: function() {
+        process.nextTick(done);
+      }
     }, {});
   });
 
@@ -52,6 +55,11 @@ describe("Map", function() {
 
   it("should render", function() {
     map.getDOMNode().className.should.match(/foo/);
+  });
+
+  it("should load leaflet + markercluster", function() {
+    L.mapbox.map.should.be.a.Function;
+    L.MarkerClusterGroup.should.be.a.Function;
   });
 });
 

--- a/test/browser/run-in-phantom.js
+++ b/test/browser/run-in-phantom.js
@@ -1,0 +1,32 @@
+var http = require('http');
+var path = require('path');
+var express = require('express');
+
+var ROOT_DIR = path.normalize(path.join(__dirname, '..', '..'));
+
+var app = express();
+
+var server = http.createServer(app);
+
+app.use(express.static(path.join(ROOT_DIR, 'dist')));
+
+server.listen(0, function() {
+  var baseURL = 'http://localhost:' + server.address().port;
+
+  var mochaPhantomPath = path.join(
+    ROOT_DIR, 'node_modules', 'mocha-phantomjs', 'bin',
+    'mocha-phantomjs'
+  );
+
+  var mochaPhantom = require('child_process').spawn(process.execPath, [
+    mochaPhantomPath,
+    baseURL + '/test/'
+  ], {
+    stdio: [0, 1, 2]
+  });
+
+  mochaPhantom.on('close', function(code) {
+    server.close();
+    process.exit(code);
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = {
                       : process.env.WEBPACK_DEVTOOL || 'eval',
   output: {
     path: __dirname + '/dist',
+    publicPath: '/',
     filename: '[name].bundle.js'
   },
   module: {


### PR DESCRIPTION
The mapbox code seems to be about 200k minified, which adds a lot to the size of our bundle, and it's all wasted if the user doesn't see the map on the clubs page, so I thought it would be a good candidate for resolving #430.

In order to add automated tests for this, I had to also make `npm run browsertest` actually set up a real server rather than access the code via a `file:` URL, which fixes #176 too.

I also went ahead and made the stylesheets be lazy-loaded as well, but we can back out this part of the PR if it's not up to snuff.