### PR TITLE
Sidebar content on mobile collapses when URL path changes.

### DIFF
--- a/components/page.jsx
+++ b/components/page.jsx
@@ -67,7 +67,7 @@ var Page = React.createClass({
          onFocus={this.state.modalClass && this.handleNonModalFocus}>
           {DevRibbon ? <DevRibbon/> : null}
           <div className="row">
-            <Sidebar/>
+            <Sidebar pathname={this.getPathname()} />
             <main className="content col-md-9">
               <RouteHandler/>
             </main>

--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -54,10 +54,20 @@ var Sidebar = React.createClass({
       ]
     }
   ],
+  propTypes: {
+    sidebar: React.PropTypes.string
+  },
   getInitialState: function() {
     return {
       showCollapsibleContent: false
     };
+  },
+  componentWillReceiveProps: function(nextProps) {
+    if (this.props.pathname !== nextProps.pathname) {
+      this.setState({
+        showCollapsibleContent: false
+      });
+    }
   },
   handleHamburgerClick: function() {
     this.setState({

--- a/test/browser/sidebar.test.jsx
+++ b/test/browser/sidebar.test.jsx
@@ -37,6 +37,20 @@ describe("sidebar", function() {
     collapsibleContent.props.className.should.eql('collapsible-content');
   });
 
+  it('should collapse when props.pathname changes', function() {
+    sidebar.props.pathname = '/foo';
+    sidebar.setState({showCollapsibleContent: true});
+    sidebar.componentWillReceiveProps({pathname: '/blah'});
+    sidebar.state.showCollapsibleContent.should.be.false;
+  });
+
+  it('should not collapse when props.pathname stays the same ', function() {
+    sidebar.props.pathname = '/blah';
+    sidebar.setState({showCollapsibleContent: true});
+    sidebar.componentWillReceiveProps({pathname: '/blah'});
+    sidebar.state.showCollapsibleContent.should.be.true;
+  });
+
   describe('hamburger', function() {
     it('should toggle collapsible content on click', function() {
       TestUtils.Simulate.click(hamburger);


### PR DESCRIPTION
This fixes #509. I didn't implement an `onClick` handler because that would also require implementing keydown handlers for accessibility and all that junk, which would additionally mean lots of unit tests.

I also figured that what we *really* want is to have the sidebar collapse on mobile whenever the current URL changes, not necessarily just when users click on a link in the sidebar. Since that was also easier to implement and test, I went with that approach.