### PR TITLE
Show add club modal on page load if ?modal=add is in url on clubs page.

### DIFF
--- a/pages/clubs.jsx
+++ b/pages/clubs.jsx
@@ -462,7 +462,7 @@ var ModalLearnMore = React.createClass({
 
 
 var ClubsPage = React.createClass({
-  mixins: [ModalManagerMixin, TeachAPIClientMixin],
+  mixins: [ModalManagerMixin, TeachAPIClientMixin, Router.State],
   statics: {
     ClubList: ClubList,
     ModalAddOrChangeYourClub: ModalAddOrChangeYourClub,
@@ -476,6 +476,10 @@ var ClubsPage = React.createClass({
   },
   componentDidMount: function() {
     this.getTeachAPI().updateClubs();
+
+    if (this.getQuery().modal === 'add') {
+      this.showAddYourClubModal();
+    }
   },
   showAddYourClubModal: function() {
     this.showModal(ModalAddOrChangeYourClub, {

--- a/test/browser/clubs-page.test.jsx
+++ b/test/browser/clubs-page.test.jsx
@@ -52,6 +52,18 @@ describe("ClubsPage", function() {
   it('triggers clubs update when mounted', function() {
     teachAPI.updateClubs.callCount.should.equal(1);
   });
+
+  it('doesn\'t show add modal if ?modal=add isn\'t in query', function() {
+    clubsPage.context.showModal.callCount.should.equal(0);
+  });
+
+  it('shows add modal if ?modal=add is in query', function() {
+    var clubsPage2 = stubContext.render(ClubsPage, {}, {
+      getCurrentQuery: function() { return {'modal': 'add'}; }
+    });
+    clubsPage2.context.showModal.callCount.should.equal(1);
+    stubContext.unmount(clubsPage2);
+  });
 });
 
 describe("ClubsPage.ClubList", function() {

--- a/test/browser/stub-context.jsx
+++ b/test/browser/stub-context.jsx
@@ -41,9 +41,9 @@ var stubContext = function(Component, props, stubs) {
         getCurrentRoutes: noop,
         getCurrentPathname: noop,
         getCurrentParams: noop,
-        getCurrentQuery: noop,
+        getCurrentQuery: function() { return {}; },
         isActive: noop,
-        showModal: noop,
+        showModal: sinon.spy(),
         hideModal: sinon.spy(),
         teachAPI: new StubTeachAPI()
       }, stubs);


### PR DESCRIPTION
This fixes #566.

Note that it doesn't remove `?modal=add` when the modal is dismissed. This is partly because it's a hassle to implement and test, but also partly because I'd like to implement a more robust solution for giving every modal its own URL in v2, which I allude to a bit in https://github.com/mozilla/teach.webmaker.org/pull/373#discussion_r26956659 (this will make it a lot easier to allow older/non-JS browsers to use the modals too, among other things). As such, this PR is really just a quick fix to unblock https://github.com/mozilla/id.webmaker.org/issues/51.