### PR TITLE
Geocoding is no longer overly specific and lame.

### DIFF
--- a/test/browser/map.test.jsx
+++ b/test/browser/map.test.jsx
@@ -28,6 +28,31 @@ var SAMPLE_BAR_CLUB = {
   name: 'bar club'
 };
 
+var BROOKLYN_GEOJSON = {
+  "id": "place.11201",
+  "type": "Feature",
+  "text": "Brooklyn",
+  "place_name": "Brooklyn, 11226, New York, United States",
+  "relevance": 0.99,
+  "center": [-73.9496, 40.6501],
+  "geometry": {
+    "type": "Point",
+    "coordinates": [-73.9496, 40.6501]
+  },
+  "bbox": [-74.04191000999859, 40.56959599007123, -73.8556849917723, 40.739421009998416],
+  "properties": {},
+  "context": [{
+    "id": "postcode.1597206218",
+    "text": "11226"
+  }, {
+    "id": "region.628083222",
+    "text": "New York"
+  }, {
+    "id": "country.4150104525",
+    "text": "United States"
+  }]
+};
+
 var STYLESHEET_URL = 'data:text/css,' + encodeURIComponent([
   '.foo {',
   '  background: pink;',
@@ -162,6 +187,25 @@ describe("Map.clubsToGeoJSON()", function() {
   });
 });
 
+describe("Map.simplifyMapboxGeoJSON()", function() {
+  var simplify = Map.simplifyMapboxGeoJSON;
+
+  it("should ignore addresses", function() {
+    simplify([{
+      "id": "address.51466244506932",
+      "place_name": "Brooklyn Rd, Brooklyn, 11210, New York, United States"
+    }]).should.eql([]);
+  });
+
+  it("should accept places", function() {
+    simplify([BROOKLYN_GEOJSON]).should.eql([{
+      location: "Brooklyn, New York, United States",
+      latitude: 40.6501,
+      longitude: -73.9496
+    }]);
+  });
+});
+
 describe("Map.getAutocompleteOptions()", function() {
   var xhr, requests;
 
@@ -208,24 +252,21 @@ describe("Map.getAutocompleteOptions()", function() {
   });
 
   it("should pass results back to callback", function(done) {
-    Map.getAutocompleteOptions('blah', function(err, info) {
+    Map.getAutocompleteOptions('brooklyn', function(err, info) {
       should(err).equal(null);
       info.options.length.should.equal(1);
       JSON.parse(info.options[0].value).should.eql({
-        location: "Somewhere",
-        latitude: 2,
-        longitude: 1
+        location: "Brooklyn, New York, United States",
+        latitude: 40.6501,
+        longitude: -73.9496
       });
-      info.options[0].label.should.eql("Somewhere");
+      info.options[0].label.should.eql("Brooklyn, New York, United States");
       done();
     });
     requests[0].respond(200, {
       'Content-Type': 'application/vnd.geo+json'
     }, JSON.stringify({
-      features: [{
-        place_name: "Somewhere",
-        center: [1, 2]
-      }]
+      features: [BROOKLYN_GEOJSON]
     }));
   });
 });


### PR DESCRIPTION
This fixes #526.

Specifically, it resolves the following problematic situations:
* Showing the zip/postal code, which is overly specific and confusing. This is now hidden from view.
* Showing both "Nairobi, Nairobi, Kenya" (the city) and "Nairobi, Kenya" (the region/county). Only the city is shown now.
* Showing both "Toronto, Ontario, Canada" (the city) and "Toronto St, Toronto, Ontario, Canada" (the address). Only the city is shown now.

Here's an animated GIF of some of those queries in action with this PR:

![geocoding](https://cloud.githubusercontent.com/assets/124687/6982696/3109c3e0-d9e3-11e4-94e4-e13d887e12c2.gif)

I should note that my fix relies a lot on the specific format of the GeoJSON that Mapbox's "public beta" geocoding API returns, but it adheres to the guidelines listed under the "Response format" section of their [geocoding API documentation](https://www.mapbox.com/developers/api/geocoding/). Specifically, we're relying on the formatting of feature IDs and feature `text`, `center`, and `context`, all of which are documented as being stable.