### PR TITLE
Add css transitions for hamburger toggle.

### DIFF
--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -76,7 +76,7 @@ var Sidebar = React.createClass({
         </div>
         <div className={this.state.showCollapsibleContent
                         ? "collapsible-content"
-                        : "hidden-xs hidden-sm collapsible-content"}>
+                        : "collapsed collapsible-content"}>
           <Login/>
           <ul className="sidebar-menu list-unstyled">
             {this.MENU_ENTRIES.map(function(entry, i) {

--- a/less/components/sidebar.less
+++ b/less/components/sidebar.less
@@ -8,7 +8,8 @@ html.no-js .sidebar {
   .collapsible-content {
     /* The links in the sidebar are crucial to navigating the site.
      * If JS is disabled, we want the links visible at all costs. */
-    display: block !important;
+    opacity: 1 !important;
+    max-height: none !important;
   }
 }
 
@@ -54,6 +55,19 @@ html.no-js .sidebar {
 
   a {
     color: inherit;
+  }
+
+  .collapsible-content {
+    transition: all 0.5s ease;
+    opacity: 1;
+    max-height: 1400px;
+  }
+
+  @media screen and (max-width: @screen-md) {
+    .collapsible-content.collapsed {
+      opacity: 0;
+      max-height: 0;
+    }
   }
 }
 

--- a/test/browser/sidebar.test.jsx
+++ b/test/browser/sidebar.test.jsx
@@ -29,7 +29,7 @@ describe("sidebar", function() {
   });
 
   it('should hide collapsible content', function() {
-    collapsibleContent.props.className.should.match(/hidden-xs/);
+    collapsibleContent.props.className.should.match(/collapsed/);
   });
 
   it('should show collapsible content', function() {


### PR DESCRIPTION
This fixes #575.

I set the transition to 0.5 seconds instead of 1 because when collapsing the burger, there is a [somewhat annoying](http://stackoverflow.com/questions/3508605/css-transition-height-0-to-height-auto#comment10354379_8331169) delay due to the fact that our `max-height` is transitioning from a very high value to 0 over that period.

This is also part of why I've added an opacity transition in addition to the max-height transition: the opacity change is immediately visible, which makes the hamburger feel more responsive when the content is being collapsed.

However, there's another reason for the opacity change too. Without it, some of the content inside the sidebar still displays when the hamburger is collapsed:

![2015-04-03_19-41-50](https://cloud.githubusercontent.com/assets/124687/6990411/81ef18a4-da39-11e4-8b5e-b755043ee3d6.jpg)

I'm not exactly sure why this is; maybe because we're using `position: relative` for some things inside the sidebar? In any case, I tried `overflow: hidden` on the sidebar content and that also results in bad things, so it was easier to just transition opacity to 0 when collapsing to ensure that the stuff inside the sidebar can't be seen.

I've tested this PR on Mobile Safari, latest Firefox, Chrome, IE11, and on a browser w/o JS enabled and all seem to work okay.