### PR TITLE
Fix scrolling in modals on iOS 8.

### DIFF
--- a/less/components/modal.less
+++ b/less/components/modal.less
@@ -90,3 +90,7 @@
   height: 100%;
 }
 
+body .modal {
+  /* Workaround for https://github.com/twbs/bootstrap/issues/14839. */
+  -webkit-overflow-scrolling: auto;
+}


### PR DESCRIPTION
This fixes #539 by overriding Bootstrap's `-webkit-overflow-scrolling` of the `.modal` class, as suggested in the [related Bootstrap issue](https://github.com/twbs/bootstrap/issues/14839).

The only side effect of this fix is that the modal no longer uses cool [kinetic scrolling](https://answers.yahoo.com/question/index?qid=20101026053313AA6aQv2). However, I think kinetic scrolling is only particularly useful for scrolling through areas that have lots of scrollable content; because our modals are all pretty small, scrolling through them in a non-kinetic way on iOS shouldn't be that big a deal.

Another aspect I like about this fix is that the CSS is only going to affect iOS, and shouldn't have weird side effects on other browsers.