### PR TITLE
homepage - edited button copy

### DIFF
--- a/pages/home.jsx
+++ b/pages/home.jsx
@@ -25,7 +25,7 @@ var HomePage = React.createClass({
       <div>
         <HeroUnit image="/img/hero-unit.jpg">
           <h1>Unlock opportunities for all citizens of the Web.</h1>
-          <div><Link to="join" className="btn btn-awsm">Join Us</Link></div>
+          <div><Link to="join" className="btn btn-awsm">Start a Mozilla Club</Link></div>
         </HeroUnit>
         <div className="inner-container">
           <div className="values">


### PR DESCRIPTION
Instead of “learn more” it now says “start a Mozilla club”

Fixes #545