### PR TITLE
Changed Sidebar color on Web Literacy page

### DIFF
--- a/less/components/sidebar.less
+++ b/less/components/sidebar.less
@@ -33,7 +33,7 @@ html.no-js .sidebar {
     .sidebarColorizer(@sidebarColor);
   }
   &.web-literacy {
-    .sidebarColorizer(@darkBlueSidebarColor);
+    .sidebarColorizer(@tealSidebarColor);
   }
 
   &.teach-like-mozilla .teach,


### PR DESCRIPTION
Now it matches Teach Like Mozilla (the parent page)

Fixes #491