### PR TITLE
Convert hamburger to <button>.

### DIFF
--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -71,8 +71,8 @@ var Sidebar = React.createClass({
           <Link to="home">
             <img src="/img/nav/mozilla-wordmark-white.svg" alt="Webmaker logo" className="moz-logo"/>
           </Link>
-          <span aria-label="toggle" role="button" onKeyUp={this.handleHamburgerClick} onKeyDown={this.handleHamburgerClick} className="glyphicon glyphicon-menu-hamburger hidden-lg hidden-md"
-                onClick={this.handleHamburgerClick} tabIndex="0" />
+          <button aria-label="toggle" className="glyphicon glyphicon-menu-hamburger hidden-lg hidden-md"
+                  onClick={this.handleHamburgerClick} />
         </div>
         <div className={this.state.showCollapsibleContent
                         ? "collapsible-content"

--- a/less/components/sidebar.less
+++ b/less/components/sidebar.less
@@ -94,8 +94,13 @@ html.no-js .sidebar {
     position: absolute;
     right: 1rem;
     top: 2.5rem;
-    cursor: pointer;
     color: @white;
+    border: none;
+    background: transparent;
+    padding: 0;
+  }
+  .glyphicon-menu-hamburger:focus {
+    color: darken(@white, 10%);
   }
 }
 

--- a/test/browser/sidebar.test.jsx
+++ b/test/browser/sidebar.test.jsx
@@ -44,12 +44,5 @@ describe("sidebar", function() {
       TestUtils.Simulate.click(hamburger);
       sidebar.state.showCollapsibleContent.should.be.false;
     });
-
-    it('should toggle collapsible content on keydown', function() {
-      TestUtils.Simulate.keyDown(hamburger, {key: 'Enter'});
-      sidebar.state.showCollapsibleContent.should.be.true;
-      TestUtils.Simulate.keyDown(hamburger, {key: 'Enter'});
-      sidebar.state.showCollapsibleContent.should.be.false;
-    });
   });
 });


### PR DESCRIPTION
This implements @ScottDowne's suggestion from #586 by converting the hamburger to a `<button>`, which means the browser takes care of all the accessibility issues for us. Yay!

Note: I noticed that there was no indication of the focus state of the button, so I added one by making the button a little bit gray.