### PR TITLE
Fix 'L is undefined' error in Map component.

### DIFF
--- a/components/map.jsx
+++ b/components/map.jsx
@@ -208,6 +208,7 @@ var Map = React.createClass({
       'mapbox.js',
       'leaflet.markercluster'
     ], function() {
+      self.mapboxLoaded = true;
       if (self.isMounted()) {
         self.handleDependenciesLoaded();
       }
@@ -284,6 +285,9 @@ var Map = React.createClass({
     this.markers.addLayer(this.geoJsonLayer);
   },
   componentDidUpdate: function(prevProps, prevState) {
+    if (!this.mapboxLoaded) {
+      return;
+    }
     if (this.props.clubs !== prevProps.clubs ||
         this.props.username !== prevProps.username) {
       this.updateMap();


### PR DESCRIPTION
Sometimes when on the clubs page, an `L is undefined` error is logged to the console.

This is occurring because sometimes the clubs page has updated the props of the Map component before the Map component has loaded leaflet/mapbox.

The Map component's `componentDidUpdate` assumes that the map has already initialized itself at the time that the props have changed; this used to always be the case, but when we made the component lazy-load mapbox/leaflet in #448, its initialization became asynchronous, which made it possible for `componentDidUpdate` to be called before the component was actually initialized.

This simple fix resolves that problem.