### PR TITLE
Support OAuth2 (take 2)

### DIFF
--- a/components/login.jsx
+++ b/components/login.jsx
@@ -57,7 +57,7 @@ var LoginLink = React.createClass({
 
     if (process.env.NODE_ENV !== 'production' &&
         !/^(signin|signup)$/.test(action)) {
-      console.warn("unrecognized action: " + this.props.action);
+      console.warn("unrecognized action: " + action);
     }
 
     return React.DOM.a(props, this.props.children);

--- a/components/login.jsx
+++ b/components/login.jsx
@@ -9,8 +9,16 @@ var ga = require('react-ga');
 
 var LogoutLink = React.createClass({
   mixins: [TeachAPIClientMixin, Router.State, React.addons.PureRenderMixin],
+  propTypes: {
+    origin: React.PropTypes.string
+  },
+  getDefaultProps: function() {
+    return {
+      origin: config.ORIGIN
+    };
+  },
   render: function() {
-    var callbackURL = config.ORIGIN + this.getPathname();
+    var callbackURL = this.props.origin + this.getPathname();
     var loginBaseURL = this.getTeachAPI().baseURL;
     var href = loginBaseURL + '/auth/oauth2/logout?callback=' +
                encodeURIComponent(callbackURL);
@@ -25,15 +33,22 @@ var LogoutLink = React.createClass({
 var LoginLink = React.createClass({
   mixins: [TeachAPIClientMixin, Router.State, React.addons.PureRenderMixin],
   propTypes: {
+    origin: React.PropTypes.string,
     callbackSearch: React.PropTypes.string,
     action: React.PropTypes.string
   },
+  getDefaultProps: function() {
+    return {
+      origin: config.ORIGIN,
+      callbackSearch: '',
+      action: 'signin'
+    };
+  },
   render: function() {
-    var callbackPath = this.getPathname() +
-                       (this.props.callbackSearch || '');
-    var callbackURL = config.ORIGIN + callbackPath;
+    var callbackPath = this.getPathname() + this.props.callbackSearch;
+    var callbackURL = this.props.origin + callbackPath;
     var loginBaseURL = this.getTeachAPI().baseURL;
-    var action = this.props.action || 'signin';
+    var action = this.props.action;
     var href = loginBaseURL + '/auth/oauth2/authorize?callback=' +
                encodeURIComponent(callbackURL) + '&action=' + action;
     var props = _.extend({}, this.props, {

--- a/components/login.jsx
+++ b/components/login.jsx
@@ -71,7 +71,6 @@ var Login = React.createClass({
     LogoutLink: LogoutLink,
     teachAPIEvents: {
       'login:error': 'handleApiLoginError',
-      'login:cancel': 'handleApiLoginCancel',
       'login:success': 'handleApiLoginSuccess',
       'logout': 'handleApiLogout'
     }
@@ -105,10 +104,6 @@ var Login = React.createClass({
     this.props.alert("An error occurred! Please try again later.");
     ga.event({ category: 'Login', action: 'Error Occurred',
                nonInteraction:true});
-  },
-  handleApiLoginCancel: function() {
-    this.setState({loggingIn: false});
-    ga.event({ category: 'Login', action: 'Cancelled Login' });
   },
   handleApiLoginSuccess: function(info) {
     this.setState({username: this.getTeachAPI().getUsername(),

--- a/components/login.jsx
+++ b/components/login.jsx
@@ -102,19 +102,9 @@ var Login = React.createClass({
                 nonInteraction:true});
     }
 
-    if (err.hasNoWebmakerAccount) {
-      this.props.alert(
-        "An error occurred when logging in. Are you sure you " +
-        "have a Webmaker account associated with the email " +
-        "address you used?"
-      );
-      ga.event({ category: 'Login', action: 'Error: Has no Webmaker Account',
-                nonInteraction:true});
-    } else {
-      this.props.alert("An error occurred! Please try again later.");
-      ga.event({ category: 'Login', action: 'Error Occurred',
-                nonInteraction:true});
-    }
+    this.props.alert("An error occurred! Please try again later.");
+    ga.event({ category: 'Login', action: 'Error Occurred',
+               nonInteraction:true});
   },
   handleApiLoginCancel: function() {
     this.setState({loggingIn: false});

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,3 +8,6 @@ exports.IN_STATIC_SITE = IN_STATIC_SITE;
 exports.GENERATING_STATIC_SITE = GENERATING_STATIC_SITE;
 exports.ENABLE_PUSHSTATE = ENABLE_PUSHSTATE;
 exports.IN_TEST_SUITE = (typeof describe == 'function');
+exports.ORIGIN = IN_STATIC_SITE ? (window.location.protocol + '//' +
+                                   window.location.host)
+                                : (process.env.ORIGIN || '');

--- a/lib/index-static.jsx
+++ b/lib/index-static.jsx
@@ -51,7 +51,6 @@ function generateWithPageHTML(url, options, pageHTML) {
         <script src="/commons.bundle.js"></script>
         <script src="/app.bundle.js"></script>
         <script src="https://mozorg.cdn.mozilla.net/tabzilla/tabzilla.js"></script>
-        <script src="https://login.persona.org/include.js" async></script>
       </body>
     </html>
   );

--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -53,37 +53,6 @@ _.extend(TeachAPI.prototype, {
     var info = this.getLoginInfo();
     return info && info.username;
   },
-  startLogin: function() {
-    if (!(process.browser && window.navigator.id)) {
-      return this.emit('login:error',
-                       new Error('navigator.id does not exist'));
-    }
-    window.navigator.id.get(function(assertion) {
-      if (!assertion) {
-        return this.emit('login:cancel');
-      }
-
-      request
-        .post(this.baseURL + '/auth/persona')
-        .type('form')
-        .send({ assertion: assertion })
-        .end(function(err, res) {
-          if (err) {
-            err.hasNoWebmakerAccount = (
-              err.response && err.response.forbidden &&
-              err.response.text == 'invalid assertion or email'
-            );
-            return this.emit('login:error', err);
-          }
-
-          // TODO: Handle a thrown exception here.
-          this.storage[STORAGE_KEY] = JSON.stringify(res.body);
-
-          this.emit('username:change', res.body.username);
-          this.emit('login:success', res.body);
-        }.bind(this));
-    }.bind(this));
-  },
   checkLoginStatus: function() {
     request.get(this.baseURL + '/auth/status')
       .withCredentials()

--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -84,6 +84,28 @@ _.extend(TeachAPI.prototype, {
         }.bind(this));
     }.bind(this));
   },
+  checkLoginStatus: function() {
+    request.get(this.baseURL + '/auth/status')
+      .withCredentials()
+      .accept('json')
+      .end(function(err, res) {
+        if (err) {
+          this.emit('login:error', err);
+          return;
+        }
+        if (res.body.username !== this.getUsername()) {
+          if (res.body.username) {
+            // TODO: Handle a thrown exception here.
+            this.storage[STORAGE_KEY] = JSON.stringify(res.body);
+
+            this.emit('username:change', res.body.username);
+            this.emit('login:success', res.body);
+          } else {
+            this.logout();
+          }
+        }
+      }.bind(this));
+  },
   request: function(method, path) {
     var info = this.getLoginInfo();
     var url = urlResolve(this.baseURL, path);

--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -54,6 +54,7 @@ _.extend(TeachAPI.prototype, {
     return info && info.username;
   },
   checkLoginStatus: function() {
+    this.emit('login:start');
     request.get(this.baseURL + '/auth/status')
       .withCredentials()
       .accept('json')
@@ -62,16 +63,14 @@ _.extend(TeachAPI.prototype, {
           this.emit('login:error', err);
           return;
         }
-        if (res.body.username !== this.getUsername()) {
-          if (res.body.username) {
-            // TODO: Handle a thrown exception here.
-            this.storage[STORAGE_KEY] = JSON.stringify(res.body);
+        if (res.body.username) {
+          // TODO: Handle a thrown exception here.
+          this.storage[STORAGE_KEY] = JSON.stringify(res.body);
 
-            this.emit('username:change', res.body.username);
-            this.emit('login:success', res.body);
-          } else {
-            this.logout();
-          }
+          this.emit('username:change', res.body.username);
+          this.emit('login:success', res.body);
+        } else {
+          this.logout();
         }
       }.bind(this));
   },

--- a/pages/clubs.jsx
+++ b/pages/clubs.jsx
@@ -14,6 +14,7 @@ var PageEndCTA = require('../components/page-end-cta.jsx');
 var Modal = require('../components/modal.jsx');
 var ModalManagerMixin = require('../mixins/modal-manager');
 var TeachAPIClientMixin = require('../mixins/teach-api-client');
+var LoginLink = require('../components/login.jsx').LoginLink;
 var ga = require('react-ga');
 
 var Illustration = require('../components/illustration.jsx');
@@ -332,10 +333,6 @@ var ModalAddOrChangeYourClub = React.createClass({
     this.hideModal();
     this.props.onSuccess(this.state.result);
   },
-  handleJoinClick: function() {
-    this.hideModal();
-    this.transitionTo('join');
-  },
   renderValidationErrors: function() {
     if (this.state.validationErrors.length) {
       return (
@@ -361,10 +358,8 @@ var ModalAddOrChangeYourClub = React.createClass({
       content = (
         <div>
           <p>Before you can {action} your club, you need to log in.</p>
-          <button className="btn btn-primary btn-block"
-           onClick={this.getTeachAPI().startLogin}>Log In</button>
-          <button className="btn btn-default btn-block"
-           onClick={this.handleJoinClick}>Create an account</button>
+          <LoginLink callbackSearch="?modal=add" className="btn btn-primary btn-block">Log In</LoginLink>
+          <LoginLink callbackSearch="?modal=add" action="signup" className="btn btn-default btn-block">Create an account</LoginLink>
         </div>
       );
     } else if (this.state.step == this.STEP_FORM ||

--- a/test/browser/clubs-page.test.jsx
+++ b/test/browser/clubs-page.test.jsx
@@ -203,28 +203,6 @@ describe("ClubsPage.ModalAddOrChangeYourClub", function() {
       modal.state.step.should.equal(modal.STEP_AUTH);
     });
 
-    it("closes modal when user clicks join btn", function() {
-      teachAPI.emit('username:change', null);
-      var joinBtn = TestUtils.findRenderedDOMComponentWithClass(
-        modal,
-        'btn-default'
-      );
-      modal.context.hideModal.callCount.should.eql(0);
-      TestUtils.Simulate.click(joinBtn);
-      modal.context.hideModal.callCount.should.eql(1);
-    });
-
-    it("starts login when user clicks login on auth step", function() {
-      teachAPI.emit('username:change', null);
-      var loginBtn = TestUtils.findRenderedDOMComponentWithClass(
-        modal,
-        'btn-primary'
-      );
-      teachAPI.startLogin.callCount.should.eql(0);
-      TestUtils.Simulate.click(loginBtn);
-      teachAPI.startLogin.callCount.should.eql(1);
-    });
-
     it("shows form when user is logged in", function() {
       teachAPI.emit('username:change', 'foo');
       modal.state.step.should.equal(modal.STEP_FORM);

--- a/test/browser/login.test.jsx
+++ b/test/browser/login.test.jsx
@@ -32,7 +32,6 @@ describe("Login", function() {
   it("removes teach API event listeners when unmounted", function() {
     var events = [
       'login:error',
-      'login:cancel',
       'login:success',
       'logout'
     ];
@@ -63,12 +62,6 @@ describe("Login", function() {
   it("shows an alert when a network error occurs", function() {
     teachAPI.emit('login:error', {});
     alerts.should.eql(["An error occurred! Please try again later."]);
-  });
-
-  it("handles login:cancel event", function() {
-    login.setState({loggingIn: true});
-    teachAPI.emit('login:cancel');
-    login.state.loggingIn.should.be.false;
   });
 
   it("handles login:success event", function() {

--- a/test/browser/login.test.jsx
+++ b/test/browser/login.test.jsx
@@ -1,13 +1,16 @@
 var EventEmitter = require('events').EventEmitter;
+var urlParse = require('url').parse;
 var should = require('should');
 var React =require('react/addons');
 var TestUtils = React.addons.TestUtils;
 
 var stubContext = require('./stub-context.jsx');
 var Login = require('../../components/login.jsx');
+var LoginLink = Login.LoginLink;
+var LogoutLink = Login.LogoutLink;
 var StubTeachAPI = require('./stub-teach-api');
 
-describe("login", function() {
+describe("Login", function() {
   var login, teachAPI, alerts;
 
   beforeEach(function() {
@@ -87,5 +90,58 @@ describe("login", function() {
     teachAPI.emit('logout');
     login.state.loggingIn.should.be.false;
     should(login.state.username).equal(null);
+  });
+});
+
+function renderLink(linkClass, props) {
+  var teachAPI = new StubTeachAPI();
+  teachAPI.baseURL = 'http://teach-api';
+  return stubContext.render(linkClass, props, {
+    teachAPI: teachAPI,
+    getCurrentPathname: function() {
+      return '/path';
+    }
+  });
+}
+
+describe("Login.LoginLink", function() {
+  it("should create a link w/ expected callback", function() {
+    var link = renderLink(LoginLink, {origin: 'http://teach'});
+    var info = urlParse(link.getDOMNode().href, true);
+
+    info.protocol.should.eql('http:');
+    info.host.should.eql('teach-api');
+    info.pathname.should.eql('/auth/oauth2/authorize');
+    info.query.action.should.eql('signin');
+    info.query.callback.should.eql('http://teach/path');
+  });
+
+  it("should accept action='signup'", function() {
+    var link = renderLink(LoginLink, {action: 'signup'});
+    var info = urlParse(link.getDOMNode().href, true);
+
+    info.query.action.should.eql('signup');
+  });
+
+  it("should accept callbackSearch prop", function() {
+    var link = renderLink(LoginLink, {
+      origin: 'http://teach',
+      callbackSearch: '?foo=on'
+    });
+    var info = urlParse(link.getDOMNode().href, true);
+
+    info.query.callback.should.eql('http://teach/path?foo=on');
+  });
+});
+
+describe("Login.LogoutLink", function() {
+  it("should create a link w/ expected callback", function() {
+    var link = renderLink(LogoutLink, {origin: 'http://teach'});
+    var info = urlParse(link.getDOMNode().href, true);
+
+    info.protocol.should.eql('http:');
+    info.host.should.eql('teach-api');
+    info.pathname.should.eql('/auth/oauth2/logout');
+    info.query.callback.should.eql('http://teach/path');
   });
 });

--- a/test/browser/login.test.jsx
+++ b/test/browser/login.test.jsx
@@ -47,30 +47,9 @@ describe("login", function() {
     login = null;
   });
 
-  it("triggers login when user clicks login link", function() {
-    var links = TestUtils.scryRenderedDOMComponentsWithTag(login, 'a');
-
-    // We should have a "create an account link" followed by a
-    // "Log in" link.
-    links.length.should.equal(2);
-
-    TestUtils.Simulate.click(links[1]);
-    teachAPI.startLogin.callCount.should.equal(1);
-    login.state.loggingIn.should.be.true;
-  });
-
   it("shows username when logged in", function() {
     login.setState({username: "blop"});
     login.getDOMNode().textContent.should.match(/blop/);
-  });
-
-  it("triggers logout when user clicks logout link", function() {
-    login.setState({username: "foo"});
-
-    var link = TestUtils.findRenderedDOMComponentWithTag(login, 'a');
-
-    TestUtils.Simulate.click(link);
-    teachAPI.logout.callCount.should.equal(1);
   });
 
   it("shows 'logging in...' when logging in", function() {

--- a/test/browser/login.test.jsx
+++ b/test/browser/login.test.jsx
@@ -11,14 +11,11 @@ var LogoutLink = Login.LogoutLink;
 var StubTeachAPI = require('./stub-teach-api');
 
 describe("Login", function() {
-  var login, teachAPI, alerts;
+  var login, teachAPI;
 
   beforeEach(function() {
     teachAPI = new StubTeachAPI();
-    alerts = [];
-    login = stubContext.render(Login, {
-      alert: function(msg) { alerts.push(msg); }
-    }, {
+    login = stubContext.render(Login, {}, {
       teachAPI: teachAPI
     });
   });
@@ -31,6 +28,7 @@ describe("Login", function() {
 
   it("removes teach API event listeners when unmounted", function() {
     var events = [
+      'login:start',
       'login:error',
       'login:success',
       'logout'
@@ -54,14 +52,15 @@ describe("Login", function() {
     login.getDOMNode().textContent.should.match(/blop/);
   });
 
-  it("shows 'logging in...' when logging in", function() {
+  it("shows 'loading...' when initializing", function() {
     login.setState({loggingIn: true});
-    login.getDOMNode().textContent.should.match(/logging in/i);
+    login.getDOMNode().textContent.should.match(/loading/i);
   });
 
-  it("shows an alert when a network error occurs", function() {
+  it("shows a message when a network error occurs", function() {
     teachAPI.emit('login:error', {});
-    alerts.should.eql(["An error occurred! Please try again later."]);
+    login.getDOMNode().textContent
+      .should.match(/unable to contact login server/i);
   });
 
   it("handles login:success event", function() {

--- a/test/browser/login.test.jsx
+++ b/test/browser/login.test.jsx
@@ -65,12 +65,6 @@ describe("Login", function() {
     alerts.should.eql(["An error occurred! Please try again later."]);
   });
 
-  it("tells user to make a webmaker account when needed", function() {
-    teachAPI.emit('login:error', {hasNoWebmakerAccount: true});
-    alerts.length.should.eql(1);
-    alerts[0].should.match(/Webmaker account/);
-  });
-
   it("handles login:cancel event", function() {
     login.setState({loggingIn: true});
     teachAPI.emit('login:cancel');

--- a/test/browser/page.test.jsx
+++ b/test/browser/page.test.jsx
@@ -14,9 +14,10 @@ var FakeModal = React.createClass({
 });
 
 describe("page", function() {
-  var handler, page;
+  var handler, page, xhr;
 
   beforeEach(function(done) {
+    xhr = sinon.useFakeXMLHttpRequest();
     Router.run(routes.routes, '/', function(Handler) {
       handler = TestUtils.renderIntoDocument(<Handler/>);
       page = TestUtils.findAllInRenderedTree(handler, function(c) {
@@ -28,6 +29,7 @@ describe("page", function() {
 
   afterEach(function() {
     React.unmountComponentAtNode(handler.getDOMNode().parentNode);
+    xhr.restore();
   });
 
   it("adds body.modal-open when modal is visible", function() {

--- a/test/browser/stub-teach-api.js
+++ b/test/browser/stub-teach-api.js
@@ -12,6 +12,7 @@ function StubTeachAPI() {
   teachAPI.addClub = sinon.spy();
   teachAPI.changeClub = sinon.spy();
   teachAPI.deleteClub = sinon.spy();
+  teachAPI.checkLoginStatus = sinon.spy();
 
   teachAPI.getUsername.returns(null);
   teachAPI.getClubs.returns([]);

--- a/test/browser/stub-teach-api.js
+++ b/test/browser/stub-teach-api.js
@@ -5,7 +5,6 @@ function StubTeachAPI() {
   var teachAPI = new EventEmitter();
 
   teachAPI.logout = sinon.spy();
-  teachAPI.startLogin = sinon.spy();
   teachAPI.getUsername = sinon.stub();
   teachAPI.getClubs = sinon.stub();
   teachAPI.updateClubs = sinon.spy();


### PR DESCRIPTION
This is a different attempt at supporting OAuth2 (#576). A few distinctions from the previous attempt in #608:

* This one *removes* support for Persona-based login. There's just such a big difference in the way that the two auth systems work that it's easier to substitute one out for the other wholesale, and migrate to it once the new auth is [stable](https://github.com/mozilla/teach.webmaker.org/issues/576#issuecomment-91233234).
* This one adds `LoginLink` and `LogoutLink` components that make it easier to add login/logout links from anywhere on the site. The links also work via standard `href` attributes rather than `onClick` handlers, since the new OAuth2 system just works by redirecting the browser to new pages.

Also, the login widget has changed so that it now looks like this when the page first loads:

![2015-04-09_17-49-51](https://cloud.githubusercontent.com/assets/124687/7077719/2818afd2-dee1-11e4-9096-697cf4d9b300.jpg)

Typically this message will only be shown for a second or two. If the login server is successfully contacted, the usual content appears depending on whether the user is logged in or not.

However, if an error occurs contacting the login server, the following appears:

![2015-04-09_17-51-08](https://cloud.githubusercontent.com/assets/124687/7077736/51069ddc-dee1-11e4-9c8f-6f83cd1c2e9e.jpg)

Still need to do:

- [x] Remove Persona-related functionality.
- [x] Add unit tests for `LoginLink`.
- [x] Add unit tests for `LogoutLink`.
- [x] Add unit tests for `TeachAPI::checkLoginStatus()`.
- [x] Make the `login:error` event trigger something other than a `window.alert()`, since it can now be triggered on page load and we don't want a modal to appear at page load.
- [ ] Figure out how we want to deal with google analytics here. (can be punted to another issue)