### PR TITLE
Fixes #622, #624 - footer padding

### DIFF
--- a/less/components/footer.less
+++ b/less/components/footer.less
@@ -1,6 +1,7 @@
 footer {
   .sidebar {
     line-height: 4rem;
+    padding: 1.5rem;
     @media (min-width: @screen-md-min) {
       align-items: flex-end;
       display: flex;


### PR DESCRIPTION
This fixes both
https://github.com/mozilla/teach.webmaker.org/issues/622 (Footer links have no left margin/padding) and https://github.com/mozilla/teach.webmaker.org/issues/624 (Footer links overflow their container on mobile)