### PR TITLE
Lazy-load Tabzilla.

### DIFF
--- a/components/page.jsx
+++ b/components/page.jsx
@@ -2,6 +2,7 @@ var React = require('react');
 var Router = require('react-router');
 var RouteHandler = Router.RouteHandler;
 
+var Tabzilla = require('./tabzilla.jsx');
 var Sidebar = require('./sidebar.jsx');
 var Footer = require('./footer.jsx');
 var TeachAPI = require('../lib/teach-api');
@@ -63,6 +64,7 @@ var Page = React.createClass({
     var pageClassName = this.getRoutes()[1].handler.pageClassName || '';
     return (
       <div>
+        <Tabzilla className="teach-tabzilla"/>
         <div className={"page container-fluid " + pageClassName}
          aria-hidden={!!this.state.modalClass}
          onFocus={this.state.modalClass && this.handleNonModalFocus}>

--- a/components/tabzilla.jsx
+++ b/components/tabzilla.jsx
@@ -1,0 +1,64 @@
+// This is a Tabzilla "lazy-loader" for sites that don't use jQuery.
+// Because Tabzilla requires jQuery and jQuery is relatively large,
+// we delay loading it until the last possible moment, when the user
+// has expressed intent to explore Tabzilla.
+//
+// Only one instance of this component is expected to ever be on the
+// page at once, and it's expected to exist for the lifetime of the
+// whole page.
+//
+// This component does require the following stylesheet to be loaded,
+// however:
+//
+//   //mozorg.cdn.mozilla.net/media/css/tabzilla-min.css
+
+var React = require('react');
+
+// This is currently the minimum version of jQuery that Tabzilla requires
+// to load.
+var JQUERY = '//mozorg.cdn.mozilla.net/media/js/libs/jquery-1.7.1.min.js';
+var TABZILLA = '//mozorg.cdn.mozilla.net/tabzilla/tabzilla.js';
+
+var Tabzilla = React.createClass({
+  propTypes: {
+    className: React.PropTypes.string
+  },
+  handleClick: function(e) {
+    if (!this.lazyLoadStarted) {
+      this.lazyLoadStarted = true;
+      e.preventDefault();
+      loadScript(JQUERY, function() {
+        loadScript(TABZILLA, function() {
+          window.Tabzilla.open();
+        });
+      });
+    }
+  },
+  render: function() {
+    return <a 
+      href="https://www.mozilla.org/"
+      id="tabzilla"
+      onClick={this.handleClick}
+      className={this.props.className}>mozilla</a>;
+  }
+});
+
+// This is based on Tabzilla's own jQuery-loading code.
+function loadScript(src, cb) {
+  var script = document.createElement("script");
+  if (script.readyState) {
+    script.onreadystatechange = function () {
+      if (script.readyState === "loaded" ||
+          script.readyState === "complete") {
+        script.onreadystatechange = null;
+        cb();
+      }
+    };
+  } else {
+    script.onload = cb;
+  }
+  script.src = src;
+  document.getElementsByTagName('head')[0].appendChild(script);
+}
+
+module.exports = Tabzilla;

--- a/lib/index-static.jsx
+++ b/lib/index-static.jsx
@@ -44,13 +44,11 @@ function generateWithPageHTML(url, options, pageHTML) {
         <title>Mozilla Learning</title>
       </head>
       <body>
-        <a href="https://www.mozilla.org/" id="tabzilla" className="teach-tabzilla">mozilla</a>
         <div id="page-holder" dangerouslySetInnerHTML={{
           __html: pageHTML
         }}></div>
         <script src="/commons.bundle.js"></script>
         <script src="/app.bundle.js"></script>
-        <script src="https://mozorg.cdn.mozilla.net/tabzilla/tabzilla.js"></script>
         <script src="https://login.persona.org/include.js" async></script>
       </body>
     </html>


### PR DESCRIPTION
This fixes #658 by only loading Tabzilla when the user has clicked/tapped on the link.

This *does* mean there is a delay between when the user clicks on the link and when Tabzilla opens. If it's really confusing for users with slow internet connections, we could either add a throbber, or just redirect to mozilla.org (the normal behavior of the link when JS is disabled) if Tabzilla/jQuery haven't loaded within a reasonable amount of time (say, 250ms).