### PR TITLE
Allow forms to disable HTML5 form validation for manual testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ JS disabled, just add `safemode=on` to the querystring when visiting the
 page. This will cause the page to operate in "safe mode", meaning that
 almost no JS will run, even if JS is enabled in the browser.
 
+If you need to make sure that a form is usable with browsers that
+don't support HTML5 form validation, see the documentation for the
+`HTML5_NOVALIDATE` environment variable below.
+
 ## Generating A Static Site
 
 Run `npm run build` to generate a static site in `dist/` that
@@ -170,6 +174,7 @@ string), the boolean is true; otherwise, it's false.
 `GA_ACCOUNT` | is the property ID of the Google Analytics account. E.g. `UA-123...`. It defaults to the property ID for the Teach site. Set it to `DISABLED` to disable Google Analytics entirely.
 `GA_DEBUG` | When set to 'on' will output verbose info to the console about what data is being sent to Google Analytics.
 `SOFTEST_OF_LAUNCHES` | When set to 'on' will enable the [softest of launches][589].
+`HTML5_NOVALIDATE` | When set to 'on' will add the `novalidate` attribute to all forms. Useful for simulating browsers that don't support [HTML5 form validation][].
 
 ### Using Environment Variables in Local Development
 
@@ -209,3 +214,4 @@ want to create a batch file that uses
   [#413]: https://github.com/mozilla/teach.webmaker.org/issues/413
   [source maps]: http://blog.teamtreehouse.com/introduction-source-maps
   [589]: https://github.com/mozilla/teach.webmaker.org/issues/589
+  [HTML5 form validation]: http://caniuse.com/#feat=form-validation

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,6 +22,10 @@ var rename = require('gulp-rename');
 
 require('node-jsx').install();
 
+if (process.env.HTML5_NOVALIDATE === 'on') {
+  require('./lib/novalidate').install();
+}
+
 // TODO: Some of our third-party components are triggering warnings
 // from react-a11y, so we need to disable it for now to prevent
 // warning spam. Hopefully in the future we can find a way to

--- a/lib/main.jsx
+++ b/lib/main.jsx
@@ -18,6 +18,10 @@ if (config.IN_STATIC_SITE && window.ENABLE_JS) {
   startRunningSite();
 }
 
+if (process.env.HTML5_NOVALIDATE === 'on') {
+  require('./novalidate').install();
+}
+
 if (process.env.NODE_ENV !== 'production') {
   require('./developer-help')();
 }

--- a/lib/novalidate.js
+++ b/lib/novalidate.js
@@ -1,0 +1,16 @@
+var _ = require('underscore');
+var React = require('react');
+
+exports.install = function() {
+  var _createElement = React.createElement;
+
+  React.createElement = function(type, props) {
+    if (type === 'form') {
+      return _createElement.apply(this, [
+        'form',
+        _.extend(props || {}, {'noValidate': true})
+      ].concat([].slice.call(arguments, 2)));
+    }
+    return _createElement.apply(this, arguments);
+  };
+};

--- a/lib/novalidate.js
+++ b/lib/novalidate.js
@@ -8,7 +8,7 @@ exports.install = function() {
     if (type === 'form') {
       return _createElement.apply(this, [
         'form',
-        _.extend(props || {}, {'noValidate': true})
+        _.extend(props || {}, { 'noValidate': true })
       ].concat([].slice.call(arguments, 2)));
     }
     return _createElement.apply(this, arguments);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,6 +40,7 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin(importEnvVars([
+      'HTML5_NOVALIDATE',
       'LESS_AUTOPREFIXER',
       'SOFTEST_OF_LAUNCHES',
       'SHOW_DEV_RIBBON',


### PR DESCRIPTION
This is an experimental PR and I'm not sure how I feel about it yet.

A few days ago @mmmavis brought up the question of how to test to make sure that our forms worked on browsers that don't support HTML5 form validation. I told her that she could use an iPhone or iPad, since Mobile Safari is the only remaining browser whose latest version still doesn't support it, but obviously this solution is suboptimal, especially for developers who don't have iOS devices on-hand.

Then I learned about the nifty [`novalidate` attribute](http://www.wufoo.com/html5/attributes/11-novalidate.html) for form elements.

This PR adds a `HTML5_NOVALIDATE` environment variable that, if set to `on`, hacks `React.createElement` to automatically add the `novalidate` attribute to all form elements generated by React code (on both the client and server/static-side).

Another option is to just point developers to http://novalidate.com/, a bookmarklet that does roughly the same thing. Or we could just tell devs to temporarily add `novalidate` to the relevant form while testing it. Or we could add a checkbox to the developer ribbon modal that allows anyone to dynamically change the value at runtime, which could make manual testing by QA folks easier. The possibilities are endless!
