### PR TITLE
Link labels to form fields in add/change club modal.

### DIFF
--- a/pages/clubs.jsx
+++ b/pages/clubs.jsx
@@ -244,7 +244,13 @@ var ModalAddOrChangeYourClub = React.createClass({
     // If club is provided, then we're a 'change' dialog, otherwise
     // we're an 'add' dialog.
     club: React.PropTypes.object,
+    idPrefix: React.PropTypes.string,
     onSuccess: React.PropTypes.func.isRequired
+  },
+  getDefaultProps: function() {
+    return {
+      idPrefix: 'ModalAddOrChangeYourClub_'
+    };
   },
   statics: {
     teachAPIEvents: {
@@ -354,6 +360,7 @@ var ModalAddOrChangeYourClub = React.createClass({
     var action = isAdd ? "add" : "change";
     var modalTitle = isAdd ? "Add Your Club To The Map"
                            : "Change Your Club";
+    var idPrefix = this.props.idPrefix;
 
     if (this.state.step == this.STEP_AUTH) {
       content = (
@@ -377,8 +384,8 @@ var ModalAddOrChangeYourClub = React.createClass({
           {this.renderValidationErrors()}
           <form onSubmit={this.handleSubmit}>
             <fieldset>
-              <label>What is the name of your Club?</label>
-              <input type="text" placeholder="We love creative Club names"
+              <label htmlFor={idPrefix + "name"}>What is the name of your Club?</label>
+              <input type="text" id={idPrefix + "name"} placeholder="We love creative Club names"
                disabled={isFormDisabled}
                required
                valueLink={this.linkState('name')} />
@@ -416,14 +423,16 @@ var ModalAddOrChangeYourClub = React.createClass({
                onChange={this.handleLocationChange} />
             </fieldset>
             <fieldset>
-              <label>What is your Club&lsquo;s website?</label>
+              <label htmlFor={idPrefix + "website"}>What is your Club&lsquo;s website?</label>
               <input type="url" placeholder="http://www.myclubwebsite.com"
+               id={idPrefix + "website"}
                disabled={isFormDisabled}
                valueLink={this.linkState('website')} />
             </fieldset>
             <fieldset>
-              <label>What do you focus your efforts on?</label>
+              <label htmlFor={idPrefix + "description"}>What do you focus your efforts on?</label>
               <textarea rows="5" placeholder="Please provide a brief description of your Club."
+               id={idPrefix + "description"}
                disabled={isFormDisabled}
                required
                valueLink={this.linkState('description')} />

--- a/test/browser/clubs-page.test.jsx
+++ b/test/browser/clubs-page.test.jsx
@@ -29,6 +29,25 @@ function ensureFormFieldsDisabledValue(component, isDisabled) {
   }
 }
 
+function ensureLabelLinkage(component, id) {
+  var el = component.getDOMNode();
+  var field = el.querySelector('#' + id);
+  var label = el.querySelector('label[for="' + id + '"]');
+
+  if (!field)
+    throw new Error('no form field found with id ' + id);
+
+  if (['input', 'textarea'].indexOf(field.nodeName.toLowerCase()) == -1)
+    throw new Error(field.nodeName.toLowerCase() +
+                    '#' + id + ' is not a form field');
+
+  if (!label)
+    throw new Error('no label found for id ' + id);
+
+  if (label.textContent.trim() == 0)
+    throw new Error('empty label found for id ' + id);
+}
+
 describe("ClubsPage", function() {
   var clubsPage, teachAPI, xhr;
 
@@ -222,6 +241,14 @@ describe("ClubsPage.ModalAddOrChangeYourClub", function() {
     it("enables form inputs by default", function() {
       teachAPI.emit('username:change', 'foo');
       ensureFormFieldsDisabledValue(modal, false);
+    });
+
+    it("has valid labels for form elements", function() {
+      teachAPI.emit('username:change', 'foo');
+
+      ensureLabelLinkage(modal, 'ModalAddOrChangeYourClub_name');
+      ensureLabelLinkage(modal, 'ModalAddOrChangeYourClub_website');
+      ensureLabelLinkage(modal, 'ModalAddOrChangeYourClub_description');
     });
 
     it("handles location changes containing JSON", function() {


### PR DESCRIPTION
This helps with #722. Note that the "where are you located" field is not currently hooked up, because `react-select` doesn't seem to support a11y at all, which is a big bummer.

Also note that this adds an optional **`idPrefix`** property to the modal component, which determines what the ultimate `id` for each form field is. While this isn't strictly needed for these forms, since they're singleton modals, I thought it would be good to follow the convention of making them configurable by the parent component, since `id` attributes are in a global namespace and therefore parent components should be able to tweak them if needed.