### PR TITLE
Rename /mozilla-web-clubs/ to /clubs/.

### DIFF
--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -25,7 +25,7 @@ var routes = (
      handler={require('../pages/events.jsx')}/>
     <Route name="event-resources" path="/events/resources/"
      handler={require('../pages/event-resources.jsx')}/>
-    <Route name="mozilla-web-clubs" path="/mozilla-web-clubs/"
+    <Route name="mozilla-web-clubs" path="/clubs/"
      handler={require('../pages/clubs.jsx')}/>
     <Route name="clubs-curriculum" path="/clubs/curriculum/"
      handler={require('../pages/clubs-curriculum.jsx')}/>


### PR DESCRIPTION
This fixes #750.

Note that the name of the route, used internally by the code, is still `mozilla-web-clubs`, which allows existing links (currently in sidebar, activities and clubs toolkit pages) to still point to the proper place.

@mmmavis can you review this?