### PR TITLE
Fixes #786 - added bg colour to hero

### DIFF
--- a/less/components/hero-unit.less
+++ b/less/components/hero-unit.less
@@ -2,6 +2,7 @@
   background-position: right top;
   background-repeat: no-repeat;
   background-size: cover;
+  background-color: @grey;
   color: white;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This fixes #786.  I didn't want to introduce another colour so I used the existing grey declared in `less/variables.less` (ie. #4D4E53)