### PR TITLE
Spider for broken links during npm test.

### DIFF
--- a/less/index.less
+++ b/less/index.less
@@ -4,6 +4,3 @@
 @import "components/index";
 @import "pages/index";
 @import "../node_modules/react-select/less/default.less";
-@import (less) "../node_modules/webmaker-app-icons/css/ionicons.css";
-
-@font-face { font-family: "Ionicons"; src: url("vendor/webmaker-app-icons/fonts/ionicons.eot?v=2.0.1"); src: url("vendor/webmaker-app-icons/fonts/ionicons.eot?v=2.0.1#iefix") format("embedded-opentype"), url("vendor/webmaker-app-icons/fonts/ionicons.ttf?v=2.0.1") format("truetype"), url("vendor/webmaker-app-icons/fonts/ionicons.woff?v=2.0.1") format("woff"), url("vendor/webmaker-app-icons/fonts/ionicons.svg?v=2.0.1#Ionicons") format("svg"); font-weight: normal; font-style: normal; }

--- a/lib/index-static.jsx
+++ b/lib/index-static.jsx
@@ -41,6 +41,7 @@ function generateWithPageHTML(url, options, pageHTML) {
         })}
         <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,700,600italic,700italic,800,800italic"/>
         <link rel="stylesheet" href="/vendor/bootstrap/css/bootstrap.min.css"/>
+        <link rel="stylesheet" href="/vendor/webmaker-app-icons/css/ionicons.min.css"/>
         <link href="https://mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet" />
         <link rel="stylesheet" href={'/' + exports.CSS_FILENAME}/>
         <script dangerouslySetInnerHTML={{

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-router": "^0.13.2",
     "react-select": "0.4.6",
     "should": "^5.1.0",
+    "simplecrawler": "^0.5.2",
     "superagent": "^1.1.0",
     "underscore": "^1.8.2",
     "vinyl": "^0.4.6",
@@ -48,7 +49,8 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "gulp smoketest && mocha test/*.test.js && npm run browsertest && gulp lint-test",
+    "test": "gulp smoketest && mocha test/*.test.js && npm run browsertest && gulp lint-test && npm run spider",
+    "spider": "node test/browser/spider.js",
     "browsertest": "node test/browser/run-in-phantom.js",
     "smoketest": "gulp smoketest",
     "s3": "gulp s3",

--- a/test/browser/spider.js
+++ b/test/browser/spider.js
@@ -1,0 +1,38 @@
+var urlParse = require('url').parse;
+var chalk = require('chalk');
+var Crawler = require('simplecrawler');
+
+var server = require('./server').create();
+
+server.listen(0, function() {
+  var baseURL = 'http://localhost:' + server.address().port;
+
+  var crawler = new Crawler("localhost", "/", server.address().port);
+
+  crawler.on('complete', function() {
+    var notfound = crawler.queue.filter(function(item) {
+      return item.status === 'notfound';
+    });
+
+    notfound.forEach(function(item) {
+      console.log("Couldn't find " + chalk.bold.red(item.path) +
+                  " referenced by " +
+                  urlParse(item.referrer).path + ".");
+    });
+
+    server.close();
+
+    if (notfound.length) {
+      console.log("Alas, some files could not be found.");
+      process.exit(1);
+    } else {
+      console.log("Fetched " +
+                  chalk.bold.green(crawler.queue.length.toString()) +
+                  " URLs without encountering any 404s.");
+    }
+  });
+
+  crawler.interval = 0;
+  crawler.parseScriptTags = false;
+  crawler.start();
+});

--- a/test/browser/spider.js
+++ b/test/browser/spider.js
@@ -5,8 +5,6 @@ var Crawler = require('simplecrawler');
 var server = require('./server').create();
 
 server.listen(0, function() {
-  var baseURL = 'http://localhost:' + server.address().port;
-
   var crawler = new Crawler("localhost", "/", server.address().port);
 
   crawler.on('complete', function() {


### PR DESCRIPTION
This fixes #804. Example output on error:

![2015-04-23_18-22-24](https://cloud.githubusercontent.com/assets/124687/7308829/c4104256-e9e5-11e4-95f4-2ebf097f19f5.png)

On success:

![2015-04-23_18-23-49](https://cloud.githubusercontent.com/assets/124687/7308845/f5cb4eee-e9e5-11e4-8b8a-2abc3611f95f.png)
