### PR TITLE
Use webpack to (re)generate index HTML files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+build
 node_modules
 .env
 .DS_Store

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -186,7 +186,7 @@ gulp.task('test-react-warnings', function() {
         this.emit('error', new Error('At least one warning was logged.'));
       }
     })
-    .pipe(gulp.dest('./dist'));
+    .on('data', function() {});
 });
 
 gulp.task('generate-index-files', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,11 +28,15 @@ require('node-jsx').install({ extension: '.jsx' });
 // require('react-a11y')();
 
 var IndexFileStream = require('./lib/gulp-index-file-stream');
-var indexStaticWatcher = require('./lib/index-static-watcher');
 var webpackConfig = require('./webpack.config');
 var config = require('./lib/config');
 var travis = require('./lib/travis');
 var server = require('./test/browser/server');
+var indexStaticWatcher = require('./lib/index-static-watcher')({
+  nodeModulesDir: path.join(__dirname, 'node_modules'),
+  outputDir: path.join(__dirname, 'dist', 'index-static'),
+  externalModules: ['react/addons']
+});
 
 var BUILD_TASKS = [
   'beautify',
@@ -213,12 +217,7 @@ gulp.task('watch', _.without(BUILD_TASKS, 'webpack'), function() {
     }, webpackConfig)))
     .pipe(gulp.dest('./dist'));
 
-  indexStaticWatcher({
-    delay: 200,
-    nodeModulesDir: path.join(__dirname, 'node_modules'),
-    outputDir: path.join(__dirname, 'dist', 'index-static'),
-    externalModules: ['react/addons']
-  }, function(indexStatic) {
+  indexStaticWatcher.watch(200, function(indexStatic) {
     new IndexFileStream(indexStatic, {})
       .on('error', function(err) {
         gutil.log('Error rebuilding index HTML files.');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,7 @@ var jshint = require('gulp-jshint');
 var autoprefixer = require('gulp-autoprefixer');
 var rename = require('gulp-rename');
 
-require('node-jsx').install();
+require('node-jsx').install({ extension: '.jsx' });
 
 // TODO: Some of our third-party components are triggering warnings
 // from react-a11y, so we need to disable it for now to prevent

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -220,6 +220,10 @@ gulp.task('watch', _.without(BUILD_TASKS, 'webpack'), function() {
     externalModules: ['react/addons']
   }, function(indexStatic) {
     new IndexFileStream(indexStatic, {})
+      .on('error', function(err) {
+        gutil.log('Error rebuilding index HTML files.');
+        gutil.log(gutil.colors.red.bold(err.stack));
+      })
       .on('end', function() {
         gutil.log('Index HTML files rebuilt.');
       })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -221,7 +221,7 @@ gulp.task('watch', _.without(BUILD_TASKS, 'webpack'), function() {
   }, function(indexStatic) {
     new IndexFileStream(indexStatic, {})
       .on('end', function() {
-        console.log("Index HTML files rebuilt.");
+        console.log('Index HTML files rebuilt.');
       })
       .pipe(gulp.dest('./dist'));
   });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,11 +30,7 @@ var webpackConfig = require('./webpack.config');
 var config = require('./lib/config');
 var travis = require('./lib/travis');
 var server = require('./test/browser/server');
-var indexStaticWatcher = require('./lib/index-static-watcher')({
-  nodeModulesDir: path.join(__dirname, 'node_modules'),
-  outputDir: path.join(__dirname, 'dist', 'index-static'),
-  externalModules: ['react/addons']
-});
+var indexStaticWatcher = require('./lib/index-static-watcher').create();
 
 var BUILD_TASKS = [
   'beautify',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -221,7 +221,7 @@ gulp.task('watch', _.without(BUILD_TASKS, 'webpack'), function() {
   }, function(indexStatic) {
     new IndexFileStream(indexStatic, {})
       .on('end', function() {
-        console.log('Index HTML files rebuilt.');
+        gutil.log('Index HTML files rebuilt.');
       })
       .pipe(gulp.dest('./dist'));
   });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -186,7 +186,11 @@ gulp.task('test-react-warnings', function() {
         this.emit('error', new Error('At least one warning was logged.'));
       }
     })
-    .on('data', function() {});
+    .on('data', function() {
+      // Drain the stream. We don't actually need to do anything with
+      // the data, we just want to make sure no warnings are logged while
+      // the stream's data is being generated.
+    });
 });
 
 gulp.task('generate-index-files', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -230,6 +230,8 @@ function watchIndexFiles() {
       ]
     },
     output: {
+      library: 'yup', // Actual value isn't used, just needs to be a string.
+      libraryTarget: 'commonjs2',
       path: outputDir,
       filename: outputFilename
     }
@@ -237,7 +239,7 @@ function watchIndexFiles() {
 
   compiler.watch(200, function(err, stats) {
     if (err) {
-      console.log("FATAL ERROR", err);
+      console.log("Fatal error during compiler.watch()", err);
       return;
     }
     var jsonStats = stats.toJson();
@@ -249,19 +251,11 @@ function watchIndexFiles() {
       console.log(stats.toString({colors: true}));
     }
     if (!hasErrors) {
-      var vm = require('vm');
       var filename = path.join(outputDir, outputFilename);
-      var js = fs.readFileSync(filename, 'utf-8');
-      var sandbox = vm.createContext({
-        process: process,
-        require: require,
-        global: global,
-        console: console
-      });
 
-      console.log("Rebuilding index HTML files.");
+      delete require.cache[filename];
 
-      var indexStatic = vm.runInContext(js, sandbox, {filename: filename});
+      var indexStatic = require(filename);
 
       new IndexFileStream(indexStatic, {})
         .on('end', function() {

--- a/lib/gulp-index-file-stream.js
+++ b/lib/gulp-index-file-stream.js
@@ -34,7 +34,10 @@ IndexFileStream.prototype._read = function() {
 
   this._indexStatic.generate(url, {
     meta: this._options.meta || {}
-  }, function(html) {
+  }, function(err, html) {
+    if (err) {
+      return this.emit('error', err);
+    }
     this.push(new File({
       cwd: this._baseDir,
       base: this._baseDir,

--- a/lib/index-static-watcher.js
+++ b/lib/index-static-watcher.js
@@ -88,4 +88,14 @@ function IndexStaticWatcher(options) {
   return self;
 }
 
+IndexStaticWatcher.create = function() {
+  var ROOT_DIR = path.normalize(path.join(__dirname, '..'));
+
+  return IndexStaticWatcher({
+    nodeModulesDir: path.join(ROOT_DIR, 'node_modules'),
+    outputDir: path.join(ROOT_DIR, 'dist', 'index-static'),
+    externalModules: ['react/addons']
+  });
+};
+
 module.exports = IndexStaticWatcher;

--- a/lib/index-static-watcher.js
+++ b/lib/index-static-watcher.js
@@ -1,3 +1,14 @@
+// This is essentially a webpack-based compiler for
+// index-static.jsx. Much of the code is largely
+// based on James Long's "Backend Apps With Webpack"
+// series of blog posts:
+//
+// http://jlongster.com/Backend-Apps-with-Webpack--Part-I
+//
+// Doing this allows us to use the same build toolchain
+// for node and the browser, and also increases
+// responsiveness during development via hot-loading.
+
 var fs = require('fs');
 var path = require('path');
 var webpack = require('webpack');
@@ -9,7 +20,9 @@ function IndexStaticWatcher(options) {
   var outputFilename = 'index-static.bundle.js';
   var indexStatic = null;
 
-  // http://jlongster.com/Backend-Apps-with-Webpack--Part-I
+  // We want to make sure that npm modules aren't bundled;
+  // we're only interested in bundling our own first-party
+  // code.
   fs.readdirSync(options.nodeModulesDir)
     .filter(function(x) {
       return ['.bin'].indexOf(x) === -1;
@@ -60,6 +73,14 @@ function IndexStaticWatcher(options) {
     } else {
       var filename = path.join(outputDir, outputFilename);
 
+      // webpack's hot-loading infrastructure is actually
+      // a bit overkill for our needs; since anything
+      // that's changed during development is in our
+      // single bundle file, and since our static site
+      // building process is stateless, we can just
+      // delete our bundle from the require cache and
+      // re-require it.
+
       delete require.cache[filename];
 
       indexStatic = require(filename);
@@ -92,7 +113,12 @@ IndexStaticWatcher.create = function() {
   return IndexStaticWatcher({
     nodeModulesDir: path.join(ROOT_DIR, 'node_modules'),
     outputDir: path.join(ROOT_DIR, 'dist', 'index-static'),
-    externalModules: ['react/addons']
+    externalModules: [
+      // Unfortunately, scanning through node_modules won't
+      // catch require()'s of npm submodules, so we need
+      // to include those manually.
+      'react/addons'
+    ]
   });
 };
 

--- a/lib/index-static-watcher.js
+++ b/lib/index-static-watcher.js
@@ -15,29 +15,25 @@ var webpack = require('webpack');
 
 function IndexStaticWatcher(options) {
   var self = {};
-  var nodeModules = {};
   var outputDir = options.outputDir;
   var outputFilename = 'index-static.bundle.js';
   var indexStatic = null;
   var buildInProgress = false;
-
-  // We want to make sure that npm modules aren't bundled;
-  // we're only interested in bundling our own first-party
-  // code.
-  fs.readdirSync(options.nodeModulesDir)
-    .filter(function(x) {
-      return ['.bin'].indexOf(x) === -1;
-    })
-    .concat(options.externalModules || [])
-    .forEach(function(mod) {
-      nodeModules[mod] = 'commonjs ' + mod;
-    });
-
+  var entry = path.join(__dirname, 'index-static.jsx');
   var compiler = webpack({
-    entry: path.join(__dirname, 'index-static.jsx'),
+    entry: entry,
     target: 'node',
     devtool: 'sourcemap',
-    externals: nodeModules,
+    externals: function(context, request, callback) {
+      if (request[0] == '.' || request == entry) {
+        // It's either our entry point or a relative module, so include
+        // it in the bundle.
+        callback();
+      } else {
+        // It's a non-relative module, so load it via require().
+        callback(null, 'commonjs ' + request);
+      }
+    },
     module: {
       loaders: [
         { test: /\.jsx$/, loader: 'jsx-loader' }
@@ -117,14 +113,7 @@ IndexStaticWatcher.create = function() {
   var ROOT_DIR = path.normalize(path.join(__dirname, '..'));
 
   return IndexStaticWatcher({
-    nodeModulesDir: path.join(ROOT_DIR, 'node_modules'),
-    outputDir: path.join(ROOT_DIR, 'dist', 'index-static'),
-    externalModules: [
-      // Unfortunately, scanning through node_modules won't
-      // catch require()'s of npm submodules, so we need
-      // to include those manually.
-      'react/addons'
-    ]
+    outputDir: path.join(ROOT_DIR, 'dist', 'index-static')
   });
 };
 

--- a/lib/index-static-watcher.js
+++ b/lib/index-static-watcher.js
@@ -63,26 +63,24 @@ function IndexStaticWatcher(options) {
       delete require.cache[filename];
 
       indexStatic = require(filename);
-
-      successCb();
+      successCb(indexStatic);
     }
   };
 
-  self.outputFilename = outputFilename;
-
-  self.getBundle = function() {
-    if (!indexStatic) {
-      throw new Error(outputFilename + ' has not yet been built');
+  self.build = function(cb) {
+    var success = function() {
+      cb(null, indexStatic);
+    };
+    if (indexStatic) {
+      return process.nextTick(success);
     }
-    return indexStatic;
+    compiler.run(onBuild.bind(null, success, function failure() {
+      cb(new Error('building ' + outputFilename + ' failed'));
+    }));
   };
 
-  self.build = function(successCb, failureCb) {
-    compiler.run(onBuild.bind(null, successCb, failureCb));
-  };
-
-  self.watch = function(delay, successCb, failureCb) {
-    compiler.watch(delay, onBuild.bind(null, successCb, failureCb));
+  self.watch = function(delay, successCb) {
+    compiler.watch(delay, onBuild.bind(null, successCb, null));
   };
 
   return self;

--- a/lib/index-static-watcher.js
+++ b/lib/index-static-watcher.js
@@ -2,7 +2,8 @@ var fs = require('fs');
 var path = require('path');
 var webpack = require('webpack');
 
-function watchIndexFiles(options, cb) {
+function IndexStaticWatcher(options) {
+  var self = {};
   var nodeModules = {};
   var outputDir = options.outputDir;
   var outputFilename = 'index-static.bundle.js';
@@ -39,7 +40,7 @@ function watchIndexFiles(options, cb) {
     }
   });
 
-  compiler.watch(options.delay, function(err, stats) {
+  var onBuild = function(cb, err, stats) {
     if (err) {
       console.log('Fatal error during compiler.watch()', err);
       return;
@@ -61,7 +62,17 @@ function watchIndexFiles(options, cb) {
 
       cb(indexStatic);
     }
-  });
+  };
+
+  self.build = function(cb) {
+    compiler.run(onBuild.bind(null, cb));
+  };
+
+  self.watch = function(delay, cb) {
+    compiler.watch(delay, onBuild.bind(null, cb));
+  };
+
+  return self;
 }
 
-module.exports = watchIndexFiles;
+module.exports = IndexStaticWatcher;

--- a/lib/index-static-watcher.js
+++ b/lib/index-static-watcher.js
@@ -27,6 +27,10 @@ function watchIndexFiles(options, cb) {
         { test: /\.jsx$/, loader: 'jsx-loader' }
       ]
     },
+    plugins: [
+      new webpack.BannerPlugin('require("source-map-support").install();',
+                               { raw: true, entryOnly: false })
+    ],
     output: {
       library: 'yup', // Actual value isn't used, just needs to be a string.
       libraryTarget: 'commonjs2',

--- a/lib/index-static-watcher.js
+++ b/lib/index-static-watcher.js
@@ -41,16 +41,16 @@ function watchIndexFiles(options, cb) {
 
   compiler.watch(options.delay, function(err, stats) {
     if (err) {
-      console.log("Fatal error during compiler.watch()", err);
+      console.log('Fatal error during compiler.watch()', err);
       return;
     }
     var jsonStats = stats.toJson();
     var hasErrors = jsonStats.errors.length > 0;
     if (hasErrors) {
-      console.log(stats.toString({colors: true}));
+      console.log(stats.toString({ colors: true }));
     }
     if (jsonStats.warnings.length > 0) {
-      console.log(stats.toString({colors: true}));
+      console.log(stats.toString({ colors: true }));
     }
     if (!hasErrors) {
       var filename = path.join(outputDir, outputFilename);

--- a/lib/index-static-watcher.js
+++ b/lib/index-static-watcher.js
@@ -19,6 +19,7 @@ function IndexStaticWatcher(options) {
   var outputDir = options.outputDir;
   var outputFilename = 'index-static.bundle.js';
   var indexStatic = null;
+  var buildInProgress = false;
 
   // We want to make sure that npm modules aren't bundled;
   // we're only interested in bundling our own first-party
@@ -90,12 +91,17 @@ function IndexStaticWatcher(options) {
 
   self.build = function(cb) {
     var success = function() {
+      buildInProgress = false;
       cb(null, indexStatic);
     };
     if (indexStatic) {
       return process.nextTick(success);
+    } else if (buildInProgress) {
+      return setTimeout(self.build.bind(null, cb), 100);
     }
+    buildInProgress = true;
     compiler.run(onBuild.bind(null, success, function failure() {
+      buildInProgress = false;
       cb(new Error('building ' + outputFilename + ' failed'));
     }));
   };

--- a/lib/index-static-watcher.js
+++ b/lib/index-static-watcher.js
@@ -1,0 +1,63 @@
+var fs = require('fs');
+var path = require('path');
+var webpack = require('webpack');
+
+function watchIndexFiles(options, cb) {
+  var nodeModules = {};
+  var outputDir = options.outputDir;
+  var outputFilename = 'index-static.bundle.js';
+
+  // http://jlongster.com/Backend-Apps-with-Webpack--Part-I
+  fs.readdirSync(options.nodeModulesDir)
+    .filter(function(x) {
+      return ['.bin'].indexOf(x) === -1;
+    })
+    .concat(options.externalModules || [])
+    .forEach(function(mod) {
+      nodeModules[mod] = 'commonjs ' + mod;
+    });
+
+  var compiler = webpack({
+    entry: path.join(__dirname, 'index-static.jsx'),
+    target: 'node',
+    devtool: 'sourcemap',
+    externals: nodeModules,
+    module: {
+      loaders: [
+        { test: /\.jsx$/, loader: 'jsx-loader' }
+      ]
+    },
+    output: {
+      library: 'yup', // Actual value isn't used, just needs to be a string.
+      libraryTarget: 'commonjs2',
+      path: outputDir,
+      filename: outputFilename
+    }
+  });
+
+  compiler.watch(options.delay, function(err, stats) {
+    if (err) {
+      console.log("Fatal error during compiler.watch()", err);
+      return;
+    }
+    var jsonStats = stats.toJson();
+    var hasErrors = jsonStats.errors.length > 0;
+    if (hasErrors) {
+      console.log(stats.toString({colors: true}));
+    }
+    if (jsonStats.warnings.length > 0) {
+      console.log(stats.toString({colors: true}));
+    }
+    if (!hasErrors) {
+      var filename = path.join(outputDir, outputFilename);
+
+      delete require.cache[filename];
+
+      var indexStatic = require(filename);
+
+      cb(indexStatic);
+    }
+  });
+}
+
+module.exports = watchIndexFiles;

--- a/lib/index-static-watcher.js
+++ b/lib/index-static-watcher.js
@@ -113,7 +113,7 @@ IndexStaticWatcher.create = function() {
   var ROOT_DIR = path.normalize(path.join(__dirname, '..'));
 
   return IndexStaticWatcher({
-    outputDir: path.join(ROOT_DIR, 'dist', 'index-static')
+    outputDir: path.join(ROOT_DIR, 'build', 'index-static')
   });
 };
 

--- a/lib/index-static-watcher.js
+++ b/lib/index-static-watcher.js
@@ -7,6 +7,7 @@ function IndexStaticWatcher(options) {
   var nodeModules = {};
   var outputDir = options.outputDir;
   var outputFilename = 'index-static.bundle.js';
+  var indexStatic = null;
 
   // http://jlongster.com/Backend-Apps-with-Webpack--Part-I
   fs.readdirSync(options.nodeModulesDir)
@@ -40,10 +41,11 @@ function IndexStaticWatcher(options) {
     }
   });
 
-  var onBuild = function(cb, err, stats) {
+  var onBuild = function(successCb, failureCb, err, stats) {
+    failureCb = failureCb || function() {};
     if (err) {
-      console.log('Fatal error during compiler.watch()', err);
-      return;
+      console.log('Fatal error while compiling ' + outputFilename, err);
+      return failureCb();
     }
     var jsonStats = stats.toJson();
     var hasErrors = jsonStats.errors.length > 0;
@@ -53,23 +55,34 @@ function IndexStaticWatcher(options) {
     if (jsonStats.warnings.length > 0) {
       console.log(stats.toString({ colors: true }));
     }
-    if (!hasErrors) {
+    if (hasErrors) {
+      failureCb();
+    } else {
       var filename = path.join(outputDir, outputFilename);
 
       delete require.cache[filename];
 
-      var indexStatic = require(filename);
+      indexStatic = require(filename);
 
-      cb(indexStatic);
+      successCb();
     }
   };
 
-  self.build = function(cb) {
-    compiler.run(onBuild.bind(null, cb));
+  self.outputFilename = outputFilename;
+
+  self.getBundle = function() {
+    if (!indexStatic) {
+      throw new Error(outputFilename + ' has not yet been built');
+    }
+    return indexStatic;
   };
 
-  self.watch = function(delay, cb) {
-    compiler.watch(delay, onBuild.bind(null, cb));
+  self.build = function(successCb, failureCb) {
+    compiler.run(onBuild.bind(null, successCb, failureCb));
+  };
+
+  self.watch = function(delay, successCb, failureCb) {
+    compiler.watch(delay, onBuild.bind(null, successCb, failureCb));
   };
 
   return self;

--- a/lib/index-static.jsx
+++ b/lib/index-static.jsx
@@ -29,8 +29,6 @@ function generateWithPageHTML(url, options, pageHTML) {
     meta: {}
   });
 
-  // Make sure any changes to this file are reflected in
-  // index.html too.
   var content = (
     <html className="no-js">
       <head>

--- a/lib/index-static.jsx
+++ b/lib/index-static.jsx
@@ -69,8 +69,16 @@ function generateWithPageHTML(url, options, pageHTML) {
 }
 
 function generate(url, options, cb) {
-  routes.generateStatic(url, function(html) {
-    cb(generateWithPageHTML(url, options, html));
+  routes.generateStatic(url, function(err, html) {
+    var pageHTML;
+
+    if (err) return cb(err);
+    try {
+      pageHTML = generateWithPageHTML(url, options, html);
+    } catch(e) {
+      err = e;
+    }
+    cb(err, pageHTML);
   });
 };
 

--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -49,7 +49,14 @@ exports.routes = routes;
 
 exports.generateStatic = function(url, cb) {
   Router.run(routes, url, function(Handler) {
-    cb(React.renderToString(<Handler/>));
+    var html;
+    var err = null;
+    try {
+      html = React.renderToString(<Handler/>);
+    } catch (e) {
+      err = e;
+    }
+    cb(err, html);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-select": "0.4.6",
     "should": "^5.1.0",
     "simplecrawler": "^0.5.2",
+    "source-map-support": "^0.2.10",
     "superagent": "^1.1.0",
     "underscore": "^1.8.2",
     "vinyl": "^0.4.6",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "mocha": "^2.1.0",
     "mocha-phantomjs": "^3.5.3",
     "mofo-style": "^1.0.1",
-    "node-jsx": "^0.13.3",
     "phantomjs": "^1.9.16",
     "react": "^0.13.1",
     "react-ga": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mocha": "^2.1.0",
     "mocha-phantomjs": "^3.5.3",
     "mofo-style": "^1.0.1",
-    "node-jsx": "^0.12.4",
+    "node-jsx": "^0.13.3",
     "phantomjs": "^1.9.16",
     "react": "^0.13.1",
     "react-ga": "^1.0.12",

--- a/test/gulp-index-file-stream.test.js
+++ b/test/gulp-index-file-stream.test.js
@@ -9,10 +9,26 @@ describe('gulp-index-file-stream', function() {
     generate: function(url, options, cb) {
       options.should.eql({meta: {}});
       process.nextTick(function() {
-        cb('i am ' + url);
+        cb(null, 'i am ' + url);
       });
     }
   };
+
+  it('should propagate errors', function(done) {
+    var stream = new IndexFileStream({
+      URLS: ['/'],
+      generate: function(url, options, cb) {
+        process.nextTick(function() {
+          cb(new Error('oof'));
+        });
+      }
+    });
+    stream.on('data', function() {});
+    stream.on('error', function(err) {
+      err.message.should.eql('oof');
+      done();
+    });
+  });
 
   it('should emit Vinyl file objects', function(done) {
     var stream = new IndexFileStream(indexStatic);

--- a/test/index-static.test.js
+++ b/test/index-static.test.js
@@ -1,6 +1,6 @@
 var should = require('should');
 
-require('node-jsx').install();
+require('node-jsx').install({ extension: '.jsx' });
 
 var indexStatic = require('../lib/index-static.jsx');
 

--- a/test/index-static.test.js
+++ b/test/index-static.test.js
@@ -6,7 +6,8 @@ var indexStatic = require('../lib/index-static.jsx');
 
 describe('index-static', function() {
   it('should work w/o meta options', function(done) {
-    indexStatic.generate('/', {}, function(html) {
+    indexStatic.generate('/', {}, function(err, html) {
+      should(err).equal(null);
       done();
     });
   });
@@ -14,7 +15,8 @@ describe('index-static', function() {
   it('should include meta options', function(done) {
     indexStatic.generate('/', {
       meta: { foo: 'bar' }
-    }, function(html) {
+    }, function(err, html) {
+      should(err).equal(null);
       html.should.match(/meta name="foo" content="bar"/);
       done();
     });

--- a/test/index-static.test.js
+++ b/test/index-static.test.js
@@ -8,13 +8,11 @@ describe('index-static', function() {
   this.timeout(10000);
 
   beforeEach(function(done) {
-    if (indexStatic) return done();
-    indexStaticWatcher.build(function success() {
-      indexStatic = indexStaticWatcher.getBundle();
+    indexStaticWatcher.build(function(err, newIndexStatic) {
+      if (err) return done(err);
+
+      indexStatic = newIndexStatic;
       done();
-    }, function fail() {
-      done(new Error('building ' + indexStaticWatcher.outputFilename +
-                     ' failed'));
     });
   });
 

--- a/test/index-static.test.js
+++ b/test/index-static.test.js
@@ -1,10 +1,23 @@
 var should = require('should');
 
-require('node-jsx').install({ extension: '.jsx' });
-
-var indexStatic = require('../lib/index-static.jsx');
+var indexStaticWatcher = require('../lib/index-static-watcher').create();
 
 describe('index-static', function() {
+  var indexStatic;
+
+  this.timeout(10000);
+
+  beforeEach(function(done) {
+    if (indexStatic) return done();
+    indexStaticWatcher.build(function success() {
+      indexStatic = indexStaticWatcher.getBundle();
+      done();
+    }, function fail() {
+      done(new Error('building ' + indexStaticWatcher.outputFilename +
+                     ' failed'));
+    });
+  });
+
   it('should work w/o meta options', function(done) {
     indexStatic.generate('/', {}, function(err, html) {
       should(err).equal(null);


### PR DESCRIPTION
While researching #585 I ran into jlongster's [Backend Apps with Webpack](http://jlongster.com/Backend-Apps-with-Webpack--Part-I) series of posts and decided to familiarize myself with using webpack in node (as opposed to the browser) by using it to watch and rebuild our static index files during `gulp watch`.

This has a number of benefits:

* **Rebuilding index HTML files is a *lot* faster.** We don't have to spawn a subprocess anymore, and webpack rebuilds only the code that's changed.
* Index HTML files are only rebuilt when an actual file they use changes. Currently, for example, changing `lib/travis.js` will trigger a full rebuild of the index HTML files, even though that file has nothing to do with rebuilding index HTML files.
* We can reuse more of our webpack code pipeline in node, rather than relying on a completely separate build toolchain (in the form of `node-jsx`). ~~We haven't completely decoupled ourselves from that toolchain yet, as everything outside of `gulp watch` still uses it, but the plan is to migrate away from it, so that our build toolchain is ultimately simplified.~~ ~~We're still using `node-jsx` but only for running node-side tests.~~ This should also make migrating to #585 (and quickly iterating on the server during development) easier.

Limitations:

* We're not rebuilding the `sitemap.xml` file in `gulp watch` anymore. Hopefully not that big a deal.
* ~~Until we've completely replaced our use of `node-jsx` with webpack, we're moving away from [dev/prod parity](http://12factor.net/dev-prod-parity), which isn't awesome. So we should finish that migration ASAP.~~
* Running the `test/index-static.test.js` test is slower because it builds the webpack bundle now, but I'd rather it just run slower than assume the developer manually builds it before running the test, and then have devs get frustrated when they change the code but the tests still fail.
* ~~We're building the index HTML generator bundle in `dist/index-static`, which probably isn't awesome because it's really just an intermediate file that isn't intended for distribution. As such, we should probably put it in some sort of intermediate directory that's also in our `.gitignore`.~~ The index HTML generator bundle is in the `build` directory, intended for intermediate build files rather than files to be distributed.