### PR TITLE
Remove jsbeautify

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,6 @@ var plumber = require('gulp-plumber');
 var merge = require('merge-stream');
 var sourcemaps = require('gulp-sourcemaps');
 var sitemap = require('gulp-sitemap');
-var beautify = require('gulp-jsbeautify');
 var jscs = require('gulp-jscs');
 var jshint = require('gulp-jshint');
 var autoprefixer = require('gulp-autoprefixer');
@@ -34,7 +33,6 @@ var travis = require('./lib/travis');
 var server = require('./test/browser/server');
 
 var BUILD_TASKS = [
-  'beautify',
   'copy-test-dirs',
   'copy-images',
   'copy-event-resources',
@@ -180,12 +178,6 @@ gulp.task('generate-index-files', function() {
     .pipe(gulp.dest('./dist'));
 });
 
-gulp.task('beautify', function () {
-  gulp.src(LINT_DIRS)
-      .pipe(beautify({ config: 'node_modules/mofo-style/linters/.jsbeautifyrc' }))
-      .pipe(gulp.dest('dist'));
-});
-
 gulp.task('jshint', function() {
   return gulp.src(LINT_DIRS)
       .pipe(jshint({ lookup: 'node_modules/mofo-style/linters/.jshintrc' }))
@@ -199,7 +191,7 @@ gulp.task('jscs', function () {
       .pipe(jscs({ configPath: 'node_modules/mofo-style/linters/.jscsrc' }));
 });
 
-gulp.task('lint-test', ['jscs', 'jshint', 'beautify']);
+gulp.task('lint-test', ['jscs', 'jshint']);
 
 gulp.task('default', BUILD_TASKS);
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "gulp-gzip": "^1.0.0",
     "gulp-html-prettify": "^0.0.1",
     "gulp-if": "^1.2.5",
-    "gulp-jsbeautify": "^0.1.1",
     "gulp-jscs": "^1.4.0",
     "gulp-jshint": "^1.9.2",
     "gulp-less": "^3.0.1",


### PR DESCRIPTION
This fixes #426 by removing "gulp beautify" entirely.

After a bit of research it appears that jsbeautify isn't a linter, it actually *reformats* your code to conform to a style guide. I don't mind linting, but I think there are potentially multiple solutions to a code style warning, and I want to be able to choose between them when I reformat my code--not have a beautifier make a decision for me.

At most, I think the beautification should be an *optional* step a developer can take to fix their lint warnings, rather than a required part of the build/test process. And since jsbeautify isn't working right now (as explained in #426) I'd rather just remove it.