### PR TITLE
Log safe mode info in Google Analytics

### DIFF
--- a/lib/main.jsx
+++ b/lib/main.jsx
@@ -1,8 +1,12 @@
 var React = require('react');
 var Router = require('react-router');
+var ga = require('react-ga');
 
 var config = require('./config');
 var routes = require('./routes.jsx');
+
+var GA_ACCOUNT = process.env.GA_ACCOUNT || 'UA-49796218-20';
+var GA_DEBUG = process.env.GA_DEBUG || 'off';
 
 function startRunningSite() {
   var pageHolder = document.getElementById('page-holder');
@@ -14,8 +18,18 @@ function startRunningSite() {
   }
 }
 
-if (config.IN_STATIC_SITE && window.ENABLE_JS) {
-  startRunningSite();
+if (config.IN_STATIC_SITE) {
+  ga.initialize(GA_ACCOUNT, { debug: GA_DEBUG === 'on' });
+  if (window.ENABLE_JS) {
+    startRunningSite();
+  } else {
+    ga.pageview(window.location.pathname);
+    ga.event({
+      category: 'JavaScript',
+      action: 'JS Disabled',
+      nonInteraction: true
+    });
+  }
 }
 
 if (process.env.NODE_ENV !== 'production') {

--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -7,8 +7,6 @@ var DefaultRoute = Router.DefaultRoute;
 var ga = require('react-ga');
 var Page = require('../components/page.jsx');
 
-var GA_ACCOUNT = process.env.GA_ACCOUNT || 'UA-49796218-20';
-var GA_DEBUG = process.env.GA_DEBUG || 'off';
 var urls = [];
 
 var routes = (
@@ -62,11 +60,6 @@ exports.generateStatic = function(url, cb) {
 };
 
 exports.run = function(location, el) {
-  var options = {};
-  if (GA_DEBUG === 'on') {
-    options.debug = true;
-  }
-  ga.initialize(GA_ACCOUNT, options);
   Router.run(routes, location, function(Handler, state) {
     ga.pageview(state.pathname);
     React.render(<Handler/>, el);


### PR DESCRIPTION
This fixes #846 by moving GA initialization from `routes.jsx` to `main.jsx` (which is really a more appropriate place for it anyways) and emitting a `ga.pageview` and a custom `ga.event` if the user is in [safe mode](https://github.com/mozilla/teach.webmaker.org/pull/579) when visiting the site.

@adamlofting can you take a look at this?