### PR TITLE
Simulate successful BSD signup in dev mode.

### DIFF
--- a/pages/events.jsx
+++ b/pages/events.jsx
@@ -36,6 +36,14 @@ var FormMailingListSignup = React.createClass({
       this.setState({validationErrors: validationErrors});
       return;
     }
+
+    if (process.env.NODE_ENV !== 'production' &&
+        !process.env.MAILINGLIST_URL) {
+      e.preventDefault();
+      alert("MAILINGLIST_URL is not defined. Simulating " +
+            "a successful mailing list signup now.");
+      window.location = "?mailinglist=thanks";
+    }
   },
   renderValidationErrors: function() {
     if (this.state.validationErrors.length) {


### PR DESCRIPTION
I noticed that if `MAILINGLIST_URL` isn't defined in the environment, signing up for the mailing list just results in the form sending a `POST` to the events page, which is confusing and not great for development. So I added a hook in the form submit handler that shows an alert message telling the developer that we're simulating a successful mailing list signup, and redirecting the user back to the events page. This makes it a bit easier to test successful signup flow during development.

The simulated behavior only occurs during development and if `MAILINGLIST_URL` isn't defined.