### PR TITLE
Improve accessibility of sidebar alt attributes.

### DIFF
--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -72,7 +72,7 @@ var Sidebar = React.createClass({
       <div className="sidebar col-md-3">
         <div className="sidebar-header">
           <Link to="home">
-            <img src="/img/components/sidebar/svg/mozilla-wordmark-white.svg" alt="Mozilla logo" className="moz-logo"/>
+            <img src="/img/components/sidebar/svg/mozilla-wordmark-white.svg" alt="Mozilla Learning Home" className="moz-logo"/>
           </Link>
           <button aria-label="toggle" className="glyphicon glyphicon-menu-hamburger hidden-lg hidden-md"
                   onClick={this.handleHamburgerClick} />
@@ -88,7 +88,10 @@ var Sidebar = React.createClass({
               return (
                 <li key={i} className={entry.className}>
                   <Link to={entry.link}>
-                    <img src={entry.icon} alt={entry.name}/>
+                    <img src={entry.icon}
+                     /* The sidebar icon is purely decorative, so leave
+                      * the alt attribute empty. */
+                     alt=""/>
                     <strong>{entry.name}</strong>
                     <div className="help-text hidden-xs hidden-sm">{entry.help}</div>
                     <span className="glyphicon glyphicon-menu-right"></span>


### PR DESCRIPTION
I was [using NVDA to test our site's accessibility](https://www.marcozehe.de/articles/how-to-use-nvda-and-firefox-to-test-your-web-pages-for-accessibility/) and noticed that we're sometimes using `alt` tags in unhelpful ways. This PR fixes a few of them in the sidebar:

* The Mozilla wordmark at the top-left of the page is actually a link to the "home" (i.e., root) of the site. This is fairly obvious to users who have vision, but just communicating "Mozilla logo" to vision-impaired users doesn't actually help them understand where the link will take them. So I changed its alt text to "Mozilla Learning Home".
* The alt text for all the sidebar icons isn't needed, because those images are purely decorative. The existing alt text we have actually results in screen readers repeating the name of the sidebar link *twice* (once from the alt text, again for the visible text), which is quite annoying. On this matter, the [W3C Techniques for providing useful text alternatives](http://dev.w3.org/html5/alt-techniques/#sec5) states:

    > Purely decorative images must be marked up so they can be ignored by assistive technology with a null alt attribute (`alt=""`) or preferably use CSS techniques. If the image isn't providing the user any informative content or enhancing greater understanding of the content, then the `alt` attribute must be empty.

    So, I set `alt=""` for all the sidebar icons. Note that this is distinctly different from leaving out the `alt` attribute altogether, as screen readers would then try to substitute something else (like the URL of the image) for the alt text.