### PR TITLE
Various easy accessibility fixes

### DIFF
--- a/components/footer.jsx
+++ b/components/footer.jsx
@@ -5,7 +5,7 @@ var Link = Router.Link;
 var Footer = React.createClass({
   render: function() {
     return (
-      <footer className="row">
+      <footer className="row" role="contentinfo">
         <div className="sidebar col-md-3">
           <div className="row">
             <div className="col-xs-6">

--- a/components/footer.jsx
+++ b/components/footer.jsx
@@ -27,10 +27,10 @@ var Footer = React.createClass({
         <div className="content col-md-9">
           <div className="row">
             <div className="col-sm-4 col-sm-offset-1">
-              <a href="http://hivelearningnetworks.org/"><img src="/img/components/footer/svg/hive-logo.svg" alt="Hive logo"/></a>
+              <a href="http://hivelearningnetworks.org/"><img src="/img/components/footer/svg/hive-logo.svg" alt="hivelearningnetworks.org"/></a>
             </div>
             <div className="col-sm-7 col-lg-5">
-              <p>The Hive Learning Networks, stewarded by Mozilla, are a growing constellation of local communities around the globe that are championing digital skills and web literacy through connected learning. <a href="http://hivelearningnetworks.org/">Learn more</a></p>
+              <p>The Hive Learning Networks, stewarded by Mozilla, are a growing constellation of local communities around the globe that are championing digital skills and web literacy through connected learning. <a href="http://hivelearningnetworks.org/">Learn more<span className="sr-only"> about Hive Learning Networks</span></a></p>
             </div>
           </div>
         </div>

--- a/components/page.jsx
+++ b/components/page.jsx
@@ -97,10 +97,15 @@ var Page = React.createClass({
         <div className={"page container-fluid " + pageClassName}
          aria-hidden={!!this.state.modalClass}
          onFocus={this.state.modalClass && this.handleNonModalFocus}>
+          <a href="#content" className="sr-only sr-only-focusable skip-to-content">
+            Skip to main content
+          </a>
+
           {DevRibbon ? <DevRibbon/> : null}
+
           <div className="row">
             <Sidebar/>
-            <main className="content col-md-9" role="main">
+            <main className="content col-md-9" role="main" id="content" tabIndex="-1">
               <RouteHandler/>
             </main>
           </div>

--- a/components/page.jsx
+++ b/components/page.jsx
@@ -100,7 +100,7 @@ var Page = React.createClass({
           {DevRibbon ? <DevRibbon/> : null}
           <div className="row">
             <Sidebar/>
-            <main className="content col-md-9">
+            <main className="content col-md-9" role="main">
               <RouteHandler/>
             </main>
           </div>

--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -69,7 +69,7 @@ var Sidebar = React.createClass({
   },
   render: function() {
     return (
-      <div className="sidebar col-md-3">
+      <div className="sidebar col-md-3" role="navigation">
         <div className="sidebar-header">
           <Link to="home">
             <img src="/img/components/sidebar/svg/mozilla-wordmark-white.svg" alt="Mozilla Learning Home" className="moz-logo"/>

--- a/less/components/page.less
+++ b/less/components/page.less
@@ -1,3 +1,19 @@
+a.skip-to-content:focus {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 100000;
+  background-color: @sidebarColor;
+  color: white;
+  padding: 0.5em;
+  outline: 1px solid white;
+}
+
+// http://getbootstrap.com/getting-started/#skip-navigation
+#content:focus {
+  outline: none;
+}
+
 .page {
   &.container-fluid {
     @media (min-width: @screen-md-min) {

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -9,6 +9,10 @@
 }
 
 .sidebarColorizer(@sidebarColor) {
+  a.skip-to-content:focus {
+    background-color: @sidebarColor;
+  }
+
   .sidebar {
     background-color: @sidebarColor;
     .sidebar-menu a {

--- a/lib/index-static.jsx
+++ b/lib/index-static.jsx
@@ -30,7 +30,7 @@ function generateWithPageHTML(url, options, pageHTML) {
   });
 
   var content = (
-    <html className="no-js">
+    <html className="no-js" lang="en">
       <head>
         <meta charSet="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>

--- a/pages/activities.jsx
+++ b/pages/activities.jsx
@@ -103,7 +103,7 @@ var HiveLink = React.createClass({
           <ImageTag className="image-tag"
             src1x={this.props.src1x}
             src2x={this.props.src2x}
-            alt={this.props.name}
+            alt=""
           />
           <span>{this.props.name}</span>
         </a>


### PR DESCRIPTION
Made a few simple accessibility fixes, many surfaced by tenon.io:

* Set `role` on the navbar, main content, and footer. In NVDA, for example, pressing `d` allows users to easily navigate between [landmark roles](http://www.w3.org/WAI/GL/wiki/Using_ARIA_landmarks_to_identify_regions_of_a_page), which makes it much easier for them to navigate to important parts of the page if these are defined.

* The list of Hives in `/activities/` has purely [decorative](https://github.com/mozilla/teach.webmaker.org/pull/905#issue-76379588) Hive logos next to each Hive city, whose `alt` attributes should be nulled.

* The "Learn more" link in the footer is unhelpful to screen reader users:

    > Do not use generic text in links. Provide text in the link that accurately and concisely indicates what will be found at the destination.

    So for screen readers this now reads as "Learn more about Hive Learning Networks". (The [`sr-only`](http://getbootstrap.com/css/#conveying-meaning-to-assistive-technologies) class is used for the extra text, so it still looks unchanged for sighted users.)

* Set `lang="en"` on the `<html>` element so that screen readers know how to pronounce the words on the page.

* Added [skip navigation](http://getbootstrap.com/getting-started/#skip-navigation). I was originally going to file this as a separate PR, but it would've conflicted with this one, so I just added it as another commit.