### PR TITLE
Ensure sidebar is uncollapsed when its items are focused

### DIFF
--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -67,6 +67,11 @@ var Sidebar = React.createClass({
       showCollapsibleContent: !this.state.showCollapsibleContent
     });
   },
+  handleFocus: function() {
+    this.setState({
+      showCollapsibleContent: true
+    });
+  },
   render: function() {
     return (
       <div className="sidebar col-md-3">
@@ -77,7 +82,8 @@ var Sidebar = React.createClass({
           <button aria-label="toggle" className="glyphicon glyphicon-menu-hamburger hidden-lg hidden-md"
                   onClick={this.handleHamburgerClick} />
         </div>
-        <div className={this.state.showCollapsibleContent
+        <div onFocus={this.handleFocus}
+             className={this.state.showCollapsibleContent
                         ? "collapsible-content"
                         : "collapsed collapsible-content"}>
 

--- a/test/browser/sidebar.test.jsx
+++ b/test/browser/sidebar.test.jsx
@@ -37,6 +37,11 @@ describe("sidebar", function() {
     collapsibleContent.props.className.should.eql('collapsible-content');
   });
 
+  it('should show collapsible content when focused', function() {
+    TestUtils.Simulate.focus(collapsibleContent);
+    collapsibleContent.props.className.should.eql('collapsible-content');
+  });
+
   describe('hamburger', function() {
     it('should toggle collapsible content on click', function() {
       TestUtils.Simulate.click(hamburger);


### PR DESCRIPTION
There's currently a bug in the collapsed (hamburger) version of the navigation whereby if the keyboard is used to navigate through the site, focus seems to "disappear" after tabbing past the hamburger. This is because focus is actually *inside* the collapsed area of the sidebar, but it's still collapsed, so it appears as though focus has been lost. Pressing tab a few more times eventually moves focus out of the sidebar and back to the main content.

One way to fix this would be to ensure that the sidebar links can't be navigated through unless the hamburger is used to toggle the navigation, but this is actually nontrivial due to the way that we're handling the collapse functionality. An easier solution is to simply ensure that the sidebar automatically un-collapses whenever any of its links are focused, which is what I've done in this PR.