### PR TITLE
Use <h4> for Expander heading.

### DIFF
--- a/components/expander.jsx
+++ b/components/expander.jsx
@@ -32,10 +32,10 @@ var Expander = React.createClass({
     return (
       <div className="expander-container">
         <div className={className} tabIndex="0" onBlur={this.collapse} onFocus={this.expand}>
-          <div onMouseDown={this.handleMouseDown} className="expander-header">
+          <h4 onMouseDown={this.handleMouseDown} className="expander-header">
             {this.props.head}
             <span className="ion"></span>
-          </div>
+          </h4>
           <div className="expander-items-container">
             <div className="items-margin">
               {this.props.children}

--- a/less/components/expander.less
+++ b/less/components/expander.less
@@ -21,6 +21,9 @@ html.no-js {
     font-weight: bold;
     text-transform: uppercase;
     padding: 2rem;
+    margin: 0;
+    font-size: inherit;
+    line-height: inherit;
     transition: background-color 0.5s ease;
     .ion {
       float: right;

--- a/less/pages/clubs-toolkit.less
+++ b/less/pages/clubs-toolkit.less
@@ -10,7 +10,6 @@
     }
   }
   .expander-header {
-    font-size: 1.5rem;
     background-color: @headerBackground;
     color: @headerText;
   }


### PR DESCRIPTION
This fixes #879 and makes navigating & understanding Expander content easier for users with screen readers. Visual styling and interactivity of Expanders for sighted users is not affected.
