### PR TITLE
Show "Site Administration" link in sidebar when user is staff

### DIFF
--- a/components/dev-ribbon.jsx
+++ b/components/dev-ribbon.jsx
@@ -97,9 +97,6 @@ var DevModal = React.createClass({
         <a href="http://invis.io/9G2DK7SR2" target="_blank" className="btn btn-block btn-default">
           <span className="glyphicon glyphicon glyphicon-plane"/> Site Map
         </a>
-        <a href={TeachAPI.getDefaultURL() + '/admin'} target="_blank" className="btn btn-block btn-default">
-          <span className="glyphicon glyphicon glyphicon-wrench"/> Admin UI
-        </a>
         <a href="https://github.com/mozilla/teach.webmaker.org/issues" target="_blank" className="btn btn-block btn-default">
           <span className="glyphicon glyphicon glyphicon-exclamation-sign"/> File An Issue on GitHub
         </a>

--- a/components/login.jsx
+++ b/components/login.jsx
@@ -123,6 +123,21 @@ var Login = React.createClass({
     this.setState({username: null, loggingIn: false});
     ga.event({ category: 'Login', action: 'Logged Out' });
   },
+  renderAdminLink: function() {
+    var adminURL = this.getTeachAPI().getAdminURL();
+
+    if (!adminURL) return null;
+    return (
+      <div>
+        <br/>
+        <span className="glyphicon glyphicon-wrench"></span>
+        &nbsp;&nbsp;
+        <a href={adminURL}>
+          Site Administration
+        </a>
+      </div>
+    );
+  },
   render: function() {
     var content;
 
@@ -149,6 +164,7 @@ var Login = React.createClass({
         <div>
           <span className="login-text">Logged in as {this.state.username}</span>
           <LogoutLink>Logout</LogoutLink>
+          {this.renderAdminLink()}
         </div>
       );
     } else {

--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -49,6 +49,10 @@ _.extend(TeachAPI.prototype, {
       return null;
     }
   },
+  getAdminURL: function() {
+    var info = this.getLoginInfo();
+    return info && (info.admin_url || null);
+  },
   getUsername: function() {
     var info = this.getLoginInfo();
     return info && info.username;

--- a/test/browser/login.test.jsx
+++ b/test/browser/login.test.jsx
@@ -60,7 +60,7 @@ describe("Login", function() {
     login.getDOMNode().textContent.should.not.match(ADMIN_RE);
   });
 
-  it("doesn't show admin link for non-staff users", function() {
+  it("shows admin link for staff users", function() {
     teachAPI.getAdminURL.returns("http://admin");
     login.setState({username: "blop"});
     login.getDOMNode().textContent.should.match(ADMIN_RE);

--- a/test/browser/login.test.jsx
+++ b/test/browser/login.test.jsx
@@ -11,6 +11,8 @@ var LogoutLink = Login.LogoutLink;
 var StubTeachAPI = require('./stub-teach-api');
 var StubRouter = require('./stub-router');
 
+var ADMIN_RE = /administration/i;
+
 describe("Login", function() {
   var login, teachAPI;
 
@@ -51,6 +53,17 @@ describe("Login", function() {
   it("shows username when logged in", function() {
     login.setState({username: "blop"});
     login.getDOMNode().textContent.should.match(/blop/);
+  });
+
+  it("doesn't show admin link for non-staff users", function() {
+    login.setState({username: "blop"});
+    login.getDOMNode().textContent.should.not.match(ADMIN_RE);
+  });
+
+  it("doesn't show admin link for non-staff users", function() {
+    teachAPI.getAdminURL.returns("http://admin");
+    login.setState({username: "blop"});
+    login.getDOMNode().textContent.should.match(ADMIN_RE);
   });
 
   it("shows 'loading...' when initializing", function() {

--- a/test/browser/stub-teach-api.js
+++ b/test/browser/stub-teach-api.js
@@ -6,6 +6,7 @@ function StubTeachAPI() {
 
   teachAPI.logout = sinon.spy();
   teachAPI.getUsername = sinon.stub();
+  teachAPI.getAdminURL = sinon.stub();
   teachAPI.getClubs = sinon.stub();
   teachAPI.updateClubs = sinon.spy();
   teachAPI.addClub = sinon.spy();
@@ -14,6 +15,7 @@ function StubTeachAPI() {
   teachAPI.checkLoginStatus = sinon.spy();
 
   teachAPI.getUsername.returns(null);
+  teachAPI.getAdminURL.returns(null);
   teachAPI.getClubs.returns([]);
 
   return teachAPI;

--- a/test/browser/teach-api.test.js
+++ b/test/browser/teach-api.test.js
@@ -114,6 +114,26 @@ describe('TeachAPI', function() {
     should(api.getUsername()).equal("boop");
   });
 
+  it('reports admin URL when user is staff', function() {
+    var api = new TeachAPI({storage: storage});
+
+    storage['TEACH_API_LOGIN_INFO'] = '{"admin_url": "http://admin"}';
+    should(api.getAdminURL()).equal("http://admin");
+  });
+
+  it('reports admin URL as null when user is not staff', function() {
+    var api = new TeachAPI({storage: storage});
+
+    storage['TEACH_API_LOGIN_INFO'] = '{"username": "boop"}';
+    should(api.getAdminURL()).equal(null);
+  });
+
+  it('reports admin URL as null if logged out', function() {
+    var api = new TeachAPI({storage: storage});
+
+    should(api.getAdminURL()).equal(null);
+  });
+
   it('reports username is null if logged out', function() {
     var api = new TeachAPI({storage: storage});
 


### PR DESCRIPTION
In https://github.com/mozilla/teach-api/commit/11ad5456a9696df1a08581414f8268f037d7492e I added support for the Teach API to tell clients if the current user is staff and, if so, what the URL for the Admin UI is.

This PR uses that new functionality to show a "Site Administration" link in the sidebar if (and only if) the user is staff:

![2015-05-18_17-57-24](https://cloud.githubusercontent.com/assets/124687/7691307/66af7978-fd87-11e4-8847-de9da7cb0d9d.jpg)

This should be particularly useful as we move towards implementing the approval flow for clubs in #911, which will require regional coordinators and teach staff to visit the admin UI more frequently, and we don't want them constantly having to remember what the link to the admin UI is. :grin: 