### PR TITLE
Add google-blog-feed-loader w/ automated and manual tests

### DIFF
--- a/lib/google-blog-feed-loader.js
+++ b/lib/google-blog-feed-loader.js
@@ -1,0 +1,91 @@
+var FEED_URL = 'https://blog.webmaker.org/tag/teachtheweb/feed';
+var DEFAULT_CONTENT_SNIPPET_WORD_COUNT = 70;
+var SCRIPT_SRC = 'https://www.google.com/jsapi';
+
+// http://stackoverflow.com/a/822464
+var HTML_TAG_RE = /<(?:.|\n)*?>/gm;
+
+var scriptLoading = false;
+var scriptLoadCallbacks = [];
+
+function handleScriptLoad() {
+  scriptLoadCallbacks.forEach(process.nextTick);
+  scriptLoadCallbacks = [];
+}
+
+function ensureGoogleAPI(callback) {
+  var head, gScript;
+
+  if (window.google) {
+    return process.nextTick(callback);
+  }
+  scriptLoadCallbacks.push(callback);
+  if (!scriptLoading) {
+    head = document.getElementsByTagName('head')[0];
+    gScript = document.createElement('script');
+    gScript.setAttribute('src', SCRIPT_SRC);
+    gScript.onload = handleScriptLoad;
+    head.appendChild(gScript);
+    scriptLoading = true;
+  }
+}
+
+function getBlogPosts(feedUrl, callback) {
+  var google = window.google;
+  google.load('feeds', '1', {
+    callback: function() {
+      var feed = new google.feeds.Feed(feedUrl);
+      feed.load(function(result) {
+        callback(formatBlogPosts(result.feed));
+      });
+    }
+  });
+}
+
+function makeContentSnippet(html, wordCount) {
+  var text = html.replace(HTML_TAG_RE, '');
+  var words;
+
+  wordCount = wordCount || DEFAULT_CONTENT_SNIPPET_WORD_COUNT;
+
+  words = text.split(' ');
+
+  if (words.length > wordCount) {
+    text = words.slice(0, wordCount).join(' ') + '\u2026';
+  }
+
+  return text;
+}
+
+function formatBlogPosts(feed) {
+  var featured = feed.entries[0];
+  var latestPosts = [];
+  var post;
+  for (var i = 1; i < 4; i++) {
+    post = feed.entries[i];
+    latestPosts.push({
+      title: post.title,
+      publishedDate: post.publishedDate,
+      link: post.link
+    });
+  }
+  return {
+    featuredPost: {
+      title: featured.title,
+      author: featured.author,
+      publishedDate: featured.publishedDate,
+      contentSnippet: makeContentSnippet(featured.content),
+      link: featured.link
+    },
+    latestPosts: latestPosts
+  };
+}
+
+function loadBlogFeed(callback) {
+  ensureGoogleAPI(function() { getBlogPosts(FEED_URL, callback); });
+}
+
+module.exports = loadBlogFeed;
+module.exports.SCRIPT_SRC = SCRIPT_SRC;
+module.exports.formatBlogPosts = formatBlogPosts;
+module.exports.makeContentSnippet = makeContentSnippet;

--- a/lib/google-blog-feed-loader.js
+++ b/lib/google-blog-feed-loader.js
@@ -5,7 +5,7 @@ var SCRIPT_SRC = 'https://www.google.com/jsapi';
 // http://stackoverflow.com/a/822464
 var HTML_TAG_RE = /<(?:.|\n)*?>/gm;
 
-var scriptLoading = false;
+var scriptEl = null;
 var scriptLoadCallbacks = [];
 
 function handleScriptLoad() {
@@ -14,19 +14,18 @@ function handleScriptLoad() {
 }
 
 function ensureGoogleAPI(callback) {
-  var head, gScript;
+  var head;
 
   if (window.google) {
     return process.nextTick(callback);
   }
   scriptLoadCallbacks.push(callback);
-  if (!scriptLoading) {
+  if (!scriptEl) {
     head = document.getElementsByTagName('head')[0];
-    gScript = document.createElement('script');
-    gScript.setAttribute('src', SCRIPT_SRC);
-    gScript.onload = handleScriptLoad;
-    head.appendChild(gScript);
-    scriptLoading = true;
+    scriptEl = document.createElement('script');
+    scriptEl.setAttribute('src', SCRIPT_SRC);
+    scriptEl.onload = handleScriptLoad;
+    head.appendChild(scriptEl);
   }
 }
 

--- a/test/browser/google-blog-feed-loader.test.js
+++ b/test/browser/google-blog-feed-loader.test.js
@@ -1,0 +1,114 @@
+var should = require('should');
+
+var loader = require('../../lib/google-blog-feed-loader');
+
+var RAW_FEED = {
+  "feedUrl": "https://blog.webmaker.org/tag/teachtheweb/feed",
+  "title": "Mozilla Learning » #teachtheweb",
+  "link": "https://blog.webmaker.org",
+  "author": "",
+  "description": "People, products and programs to teach, learn and make the Web",
+  "type": "rss20",
+  "entries": [
+    {
+      "title": "What’s next for Thimble?",
+      "link": "https://blog.webmaker.org/whats-next-for-thimble",
+      "author": "Hannah Kane",
+      "publishedDate": "Tue, 12 May 2015 10:47:33 -0700",
+      "contentSnippet": "Last week we announced that Thimble will soon be moving over to our new site for people who teach the web, teach.mozilla.org. ...",
+      "content": "<p>Last week we <a href=\"https://blog.webmaker.org/whats-next-for-webmaker-tools\">announced</a> that Thimble will soon be moving over to our new site for people who teach the web, teach.mozilla.org. We also shared that Professor David Humphrey and a team of students from Seneca College have been working to make Thimble an even more powerful teaching, learning, and development tool.</p>\n<p>We wanted to follow up with more specifics about what you can expect from the new Thimble:</p>\n<ul>\n<li>Over the next few months, we’re focusing on <strong>making Thimble an even more useful tool, both for beginners and professionals</strong>. Thimble has always been well suited for new makers, and we are going to keep that focus. However, we’re also going to allow the user to turn on more powerful features as they learn new skills, and have Thimble grow to match their teaching and learning needs. Our goal is to make sure that Thimble can continue to serve users, no matter what level they are at in their web making experience.</li>\n<li>We’re also focusing on making Thimble <strong>a powerful tool for teaching others how to be creators</strong> <strong>of the Web</strong>. Imagine improved tutorials, error messages that serve as learning opportunities, and an environment that can be enhanced as you learn with more advanced extensions.</li>\n<li>We also want to <strong>improve the user experience and functionality</strong>. Though the roadmap is a work-in-progress, we’re already thinking about integration with Dropbox, collaborative editing, and improved image handling. The Selfie feature is an example:</li>\n</ul>\n<p><span style=\"text-align:center;display:block\"><iframe width=\"640\" height=\"390\" src=\"https://www.youtube.com/embed/t7V3h2x-5JU?version=3&amp;rel=1&amp;fs=1&amp;showsearch=0&amp;showinfo=1&amp;iv_load_policy=1&amp;wmode=transparent\" frameborder=\"0\" allowFullScreen=\"true\"></iframe></span></p>\n<p><strong>How are we doing this? Thimble is going to integrate Brackets.<br>\n</strong><br>\n<a href=\"http://brackets.io/\">Brackets</a> is a lightweight, powerful, open source code editor for the Web. While it was originally designed to run on the desktop as a native application, the Seneca College team has been working to integrate Brackets into the Web and Thimble (code name “Bramble” for “Brackets in Thimble”). Soon you’ll see improvements like these:</p>\n<ul>\n<li>multiple-file support (for more complex web sites, apps with files and folders)</li>\n<li>smarter live preview, with highlighting, desktop and mobile modes, and more</li>\n<li>image preview on URL hover</li>\n<li>inline editors for JavaScript, CSS, and colors</li>\n<li>autocomplete for <b>everything</b></li>\n<li>auto-closing tags and strings</li>\n<li>real-time JavaScript analysis, with intellisense style suggestions</li>\n<li>extensions, and so much more</li>\n</ul>\n<p>In the meantime, you can:</p>\n<ul>\n<li>check out the work we’re doing on <a href=\"https://bramble.mofostaging.net\">https://bramble.mofostaging.net</a></li>\n<li>follow along, contribute, or report issues and ideas here: <a href=\"https://github.com/mozilla/thimble.webmaker.org/issues\">https://github.com/mozilla/thimble.webmaker.org/issues</a></li>\n<li>hang out with us in the #thimble channel on irc!</li>\n</ul>\n<p>p.s. If you’re interested in being a user tester for new Thimble features, please email hannah@mozillafoundation.org.</p>",
+      "categories": [
+        "Teaching",
+        "Webmaking",
+        "#teachtheweb",
+        "brackets",
+        "Thimble"
+      ]
+    },
+    {
+      "title": "What’s next for Webmaker tools",
+      "link": "https://blog.webmaker.org/whats-next-for-webmaker-tools",
+      "author": "Mozilla Webmaker",
+      "publishedDate": "Mon, 04 May 2015 11:53:23 -0700",
+      "contentSnippet": "Thanks to our devoted community, Webmaker has grown substantially over the years. And with growth often comes change. Our ...",
+      "content": "",
+      "categories": [
+        "Teaching",
+        "Updates",
+        "Webmaking",
+        "#teachtheweb"
+      ]
+    },
+    {
+      "title": "Understanding Web Literacy within the Web Journey",
+      "link": "https://blog.webmaker.org/understanding-web-literacy-within-the-web-journey",
+      "author": "Laura de Reynal",
+      "publishedDate": "Tue, 21 Apr 2015 08:04:56 -0700",
+      "contentSnippet": "Since 2012, pioneering educators and web activists have been reflecting and developing answers to the question, &#8220;What is ...",
+      "content": "",
+      "categories": [
+        "Research",
+        "Uncategorized",
+        "#teachtheweb",
+        "get involved",
+        "Web Journey",
+        "web literacy"
+      ]
+    },
+    {
+      "title": "Learning Through Making: The Best Kind of Education",
+      "link": "https://blog.webmaker.org/learning-through-making-the-best-kind-of-education",
+      "author": "Chris Lawrence",
+      "publishedDate": "Thu, 16 Apr 2015 12:04:55 -0700",
+      "contentSnippet": "Learning scientists and educational philosophers have long understood that when we learn with the combination of our hands and ...",
+      "content": "",
+      "categories": [
+        "Mozilla",
+        "Teaching",
+        "#teachtheweb"
+      ]
+    }
+  ]
+};
+
+describe('GoogleBlogFeedLoader', function() {
+  it('should convert HTML content snippet to plain text', function() {
+    loader.makeContentSnippet('<p>hello there</p>', 1000)
+      .should.eql('hello there');
+  });
+
+  it('should limit word count of content snippet', function() {
+    loader.makeContentSnippet('hello there human', 2)
+      .should.eql('hello there\u2026');
+  });
+
+  it('should provide featured post metadata', function() {
+    loader.formatBlogPosts(RAW_FEED).featuredPost.should.eql({
+      author: 'Hannah Kane',
+      link: 'https://blog.webmaker.org/whats-next-for-thimble',
+      contentSnippet: 'Last week we announced that Thimble will soon be moving over to our new site for people who teach the web, teach.mozilla.org. We also shared that Professor David Humphrey and a team of students from Seneca College have been working to make Thimble an even more powerful teaching, learning, and development tool.\nWe wanted to follow up with more specifics about what you can expect from the new Thimble:\n\nOver the next\u2026',
+      publishedDate: 'Tue, 12 May 2015 10:47:33 -0700',
+      title: 'What’s next for Thimble?'
+    });
+  });
+
+  it('should provide latest posts metadata', function() {
+    loader.formatBlogPosts(RAW_FEED).latestPosts.should.eql([
+      {
+        link: 'https://blog.webmaker.org/whats-next-for-webmaker-tools',
+        publishedDate: 'Mon, 04 May 2015 11:53:23 -0700',
+        title: 'What’s next for Webmaker tools'
+      },
+      {
+        link: 'https://blog.webmaker.org/understanding-web-literacy-within-the-web-journey',
+        publishedDate: 'Tue, 21 Apr 2015 08:04:56 -0700',
+        title: 'Understanding Web Literacy within the Web Journey'
+      },
+      {
+        link: 'https://blog.webmaker.org/learning-through-making-the-best-kind-of-education',
+        publishedDate: 'Thu, 16 Apr 2015 12:04:55 -0700',
+        title: 'Learning Through Making: The Best Kind of Education'
+      }
+    ]);
+  });
+});

--- a/test/browser/manual-google-blog-feed-loader.jsx
+++ b/test/browser/manual-google-blog-feed-loader.jsx
@@ -1,0 +1,73 @@
+var React = require('react/addons');
+var GoogleBlogFeedLoader = require('../../lib/google-blog-feed-loader');
+
+var jsonToDataURL = function(obj) {
+  var base64 = new Buffer(JSON.stringify(obj, null, 2)).toString('base64');
+  return 'data:application/json;charset=utf-8;base64,' + base64;
+};
+
+var GoogleBlogFeedLoaderTest = React.createClass({
+  getInitialState: function() {
+    return {
+      results: [],
+      scriptTagCount: 0
+    };
+  },
+  checkStatus: function() {
+    var scriptTagCount = 0;
+
+    for (var i = 0; i < document.scripts.length; i++) {
+      if (document.scripts[i].src === GoogleBlogFeedLoader.SCRIPT_SRC) {
+        scriptTagCount++;
+      }
+    }
+
+    this.setState({
+      scriptTagCount: scriptTagCount
+    });
+  },
+  componentDidMount: function() {
+    this.interval = window.setInterval(this.checkStatus, 1000);
+    this.checkStatus();
+  },
+  componentWillUnmount: function() {
+    window.clearInterval(this.interval);
+  },
+  handleLoadClick: function() {
+    GoogleBlogFeedLoader(function(results) {
+      this.checkStatus();
+      this.setState({
+        results: this.state.results.concat([{
+          dataURL: jsonToDataURL(results),
+          timestamp: new Date()
+        }])
+      });
+    }.bind(this));
+  },
+  render: function() {
+    return (
+      <div>
+        <h3>Google Blog Feed Loader</h3>
+        <p><small>
+          Google script tags loaded: <code>{this.state.scriptTagCount}</code> (should never be &gt; 1)
+        </small></p>
+        <button className="btn btn-default btn-xs" onClick={this.handleLoadClick}>
+          Load Blog Posts
+        </button>
+        <ul>
+          {this.state.results.map(function(result, i) {
+            return (
+              <li key={i}>
+                <a href={result.dataURL} target="_blank">
+                  JSON data received @ {result.timestamp.toString()}
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    );
+  }
+});
+
+module.exports = GoogleBlogFeedLoaderTest;

--- a/test/browser/manual-main.jsx
+++ b/test/browser/manual-main.jsx
@@ -1,6 +1,7 @@
 var querystring = require('querystring');
 var React = require('react/addons');
 
+var GoogleBlogFeedLoader = require('./manual-google-blog-feed-loader.jsx');
 var DevRibbon = require('../../components/dev-ribbon.jsx');
 var routes = require('../../lib/routes.jsx');
 
@@ -151,6 +152,10 @@ var ManualTests = React.createClass({
         </nav>
         <div className="container-fluid">
           <h1>Manual Tests</h1>
+          <h2>Internet Services</h2>
+          <p>The following require internet services to work and may be slow depending on your network connection.</p>
+          <GoogleBlogFeedLoader/>
+          <h2>Routes</h2>
           <p>Below are thumbnails of all the pages on the site, rendered <strong>{
             this.props.enableJS ? "with" : "without"
           }</strong> JavaScript enabled.</p>


### PR DESCRIPTION
This adds an implementation of a google blog feed loader, based on @mmmavis's original code from #943.

Automated tests ensure that the raw feed provided by Google is processed properly.

Manual tests ensure that we can connect to the Google feed API and obtain proper results. It adds a new "Internet Services" section to the Manual Tests page:

![2015-05-28_9-19-38](https://cloud.githubusercontent.com/assets/124687/7860904/de0eea22-051a-11e5-9fed-e29ac837e512.jpg)

Clicking on the "Load Blog Posts" button logs links below it, which are Data URLs containing the JSON response for testers to peruse:

![2015-05-28_9-20-50](https://cloud.githubusercontent.com/assets/124687/7860926/0694313c-051b-11e5-9ec3-7298fbea8ed6.jpg)

We also show how many `<script>` tags pointing at Google's JS API have been loaded, which helps us ensure that we're not accidentally loading multiple script tags or anything.