### PR TITLE
[WIP] Translate weblitmap

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ var jshint = require('gulp-jshint');
 var autoprefixer = require('gulp-autoprefixer');
 var rename = require('gulp-rename');
 
+var TransifexFileStream = require('./lib/transifex');
 var IndexFileStream = require('./lib/gulp-index-file-stream');
 var webpackConfig = require('./webpack.config');
 var config = require('./lib/config');
@@ -140,6 +141,22 @@ gulp.task('less', function() {
     .pipe(rename('styles.css'))
     .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest('./dist'));
+});
+
+gulp.task('transifex', function() {
+  var userpass = (process.env.TRANSIFEX_USERPASS || '').match(/^(.+):(.+)$/);
+
+  if (!userpass) {
+    throw new Error('Please set TRANSIFEX_USERPASS in your environment ' +
+                    'to a string of the form `user:pass`.');
+  }
+
+  return new TransifexFileStream({
+    project: 'webmaker',
+    resource: 'weblit',
+    user: userpass[1],
+    pass: userpass[2]
+  }).pipe(gulp.dest('./locale/weblit'));
 });
 
 gulp.task('webpack', function() {

--- a/lib/transifex.js
+++ b/lib/transifex.js
@@ -1,0 +1,69 @@
+var Readable = require('stream').Readable;
+var path = require('path');
+var util = require('util');
+var request = require('superagent');
+var File = require('vinyl');
+
+function TransifexFileStream(options) {
+  Readable.call(this, {
+    objectMode: true
+  });
+  this._baseURL = 'http://www.transifex.com/api/2/project/' +
+                  options.project + '/resource/' + options.resource;
+  this._user = options.user;
+  this._pass = options.pass;
+  this._locales = null;
+  this._options = options;
+}
+
+util.inherits(TransifexFileStream, Readable);
+
+TransifexFileStream.prototype._fetchStats = function() {
+  request
+    .get(this._baseURL + '/stats/')
+    .auth(this._user, this._pass)
+    .end(function(err, res) {
+      if (err) {
+        return this.emit('error', err);
+      }
+      this._locales = Object.keys(res.body).filter(function(locale) {
+        return res.body[locale].untranslated_entities === 0;
+      }).sort();
+      this._readNextLocale();
+    }.bind(this));
+};
+
+TransifexFileStream.prototype._readNextLocale = function() {
+  if (this._locales.length == 0) {
+    return this.push(null);
+  }
+  var locale = this._locales.shift();
+  request
+    .get(this._baseURL + '/translation/' + locale + '/strings')
+    .auth(this._user, this._pass)
+    .end(function(err, res) {
+      var strings = {};
+      if (err) {
+        return this.emit('error', err);
+      }
+      res.body.forEach(function(info) {
+        strings[info.key] = info.translation || info.source_string
+      });
+      this.push(new File({
+        cwd: this._baseDir,
+        base: this._baseDir,
+        path: locale + '.json',
+        contents: new Buffer(JSON.stringify(strings))
+      }));
+    }.bind(this));
+};
+
+TransifexFileStream.prototype._read = function() {
+  if (this._locales === null) {
+    this._fetchStats();
+  } else {
+    this._readNextLocale();
+  }
+};
+
+module.exports = TransifexFileStream;

--- a/lib/transifex.js
+++ b/lib/transifex.js
@@ -34,7 +34,7 @@ TransifexFileStream.prototype._fetchStats = function() {
 };
 
 TransifexFileStream.prototype._readNextLocale = function() {
-  if (this._locales.length == 0) {
+  if (this._locales.length === 0) {
     return this.push(null);
   }
   var locale = this._locales.shift();
@@ -47,7 +47,7 @@ TransifexFileStream.prototype._readNextLocale = function() {
         return this.emit('error', err);
       }
       res.body.forEach(function(info) {
-        strings[info.key] = info.translation || info.source_string
+        strings[info.key] = info.translation || info.source_string;
       });
       this.push(new File({
         cwd: this._baseDir,

--- a/lib/transifex.js
+++ b/lib/transifex.js
@@ -1,6 +1,7 @@
 var Readable = require('stream').Readable;
 var path = require('path');
 var util = require('util');
+var stableStringify = require('json-stable-stringify');
 var request = require('superagent');
 var File = require('vinyl');
 
@@ -10,6 +11,7 @@ function TransifexFileStream(options) {
   });
   this._baseURL = 'http://www.transifex.com/api/2/project/' +
                   options.project + '/resource/' + options.resource;
+  this._baseDir = __dirname;
   this._user = options.user;
   this._pass = options.pass;
   this._locales = null;
@@ -52,8 +54,10 @@ TransifexFileStream.prototype._readNextLocale = function() {
       this.push(new File({
         cwd: this._baseDir,
         base: this._baseDir,
-        path: locale + '.json',
-        contents: new Buffer(JSON.stringify(strings))
+        path: path.join(this._baseDir, locale + '.json'),
+        contents: new Buffer(stableStringify(strings, {
+          space: 2
+        }))
       }));
     }.bind(this));
 };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "webmaker-app-icons": "git://github.com/k88hudson/ionicons#teach",
     "webpack": "^1.6.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "nock": "^2.3.0"
+  },
   "scripts": {
     "pretest": "rm -rf dist",
     "test": "gulp smoketest && mocha test/*.test.js && npm run browsertest && gulp lint-test && npm run spider",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "webpack": "^1.6.0"
   },
   "devDependencies": {
+    "json-stable-stringify": "^1.0.0",
     "nock": "^2.3.0"
   },
   "scripts": {

--- a/test/transifex.test.js
+++ b/test/transifex.test.js
@@ -1,0 +1,125 @@
+var path = require('path');
+var _ = require('underscore');
+var should = require('should');
+var nock = require('nock');
+
+var TransifexFileStream = require('../lib/transifex');
+
+var SAMPLE_STATS = {
+  "en_US": {
+    "reviewed_percentage": "0%", 
+    "completed": "100%", 
+    "untranslated_words": 0, 
+    "last_commiter": "aali", 
+    "reviewed": 0, 
+    "translated_entities": 108, 
+    "translated_words": 867, 
+    "last_update": "2014-08-15 09:49:02", 
+    "untranslated_entities": 0
+  }, 
+  "es": {
+    "reviewed_percentage": "97%", 
+    "completed": "100%", 
+    "untranslated_words": 0, 
+    "last_commiter": "inma610", 
+    "reviewed": 105, 
+    "translated_entities": 108, 
+    "translated_words": 867, 
+    "last_update": "2015-04-15 13:35:39", 
+    "untranslated_entities": 0
+  },
+  "ta_IN": {
+    "reviewed_percentage": "0%", 
+    "completed": "0%", 
+    "untranslated_words": 866, 
+    "last_commiter": "aali", 
+    "reviewed": 0, 
+    "translated_entities": 1, 
+    "translated_words": 1, 
+    "last_update": "2014-11-09 21:59:44", 
+    "untranslated_entities": 107
+  }
+};
+
+var SAMPLE_ES_STRINGS = [
+  {
+    "comment": "", 
+    "context": "", 
+    "key": "StandardBuildingRemixingPoint1", 
+    "reviewed": true, 
+    "pluralized": false, 
+    "source_string": "Identifying and using openly-licensed work", 
+    "translation": "Identificar y usar trabajos con licencias abiertas "
+  }, 
+  {
+    "comment": "", 
+    "context": "", 
+    "key": "StandardExploringWM", 
+    "reviewed": true, 
+    "pluralized": false, 
+    "source_string": "Web Mechanics", 
+    "translation": "Mecánica de la Web"
+  }, 
+  {
+    "comment": "", 
+    "context": "", 
+    "key": "StandardBuildingCodingPoint4", 
+    "reviewed": true, 
+    "pluralized": false, 
+    "source_string": "Using a script framework", 
+    "translation": "Usar un framework de código"
+  }
+];
+
+var SAMPLE_EN_US_STRINGS = SAMPLE_ES_STRINGS.map(function(info) {
+  return _.extend({}, info, {translation: ''});
+});
+
+describe('TransifexFileStream', function() {
+  it('should emit Vinyl file objects', function(done) {
+    var stream = new TransifexFileStream({
+      project: 'webmaker',
+      resource: 'weblit',
+      user: 'foo',
+      pass: 'bar'
+    });
+    var transifex = nock('http://www.transifex.com/')
+      .get('/api/2/project/webmaker/resource/weblit/stats/')
+      .basicAuth({user: 'foo', pass: 'bar'})
+      .reply(200, SAMPLE_STATS)
+      .get('/api/2/project/webmaker/resource/weblit/translation/es/strings')
+      .basicAuth({user: 'foo', pass: 'bar'})
+      .reply(200, SAMPLE_ES_STRINGS)
+      .get('/api/2/project/webmaker/resource/weblit/translation/en_US/strings')
+      .basicAuth({user: 'foo', pass: 'bar'})
+      .reply(200, SAMPLE_EN_US_STRINGS);
+    var files = [];
+
+    stream.on('data', function(file) {
+      files.push({
+        path: '/' + path.relative(file.base, file.path)
+          .split(path.sep).join('/'),
+        contents: JSON.parse(file.contents)
+      });
+    });
+    stream.on('end', function() {
+      files.should.eql([{
+        path: '/en_US.json',
+        contents: {
+          'StandardBuildingRemixingPoint1': 'Identifying and using openly-licensed work',
+          'StandardExploringWM': 'Web Mechanics',
+          'StandardBuildingCodingPoint4': 'Using a script framework'
+        }
+      }, {
+        path: '/es.json',
+        contents: {
+          'StandardBuildingRemixingPoint1': 'Identificar y usar trabajos con licencias abiertas ',
+          'StandardExploringWM': 'Mecánica de la Web',
+          'StandardBuildingCodingPoint4': 'Usar un framework de código'
+        }
+      }]);
+      transifex.done();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
This is an attempt at fixing, or at least laying the foundation for fixing, #947.

To do:
- [X] Add a `gulp transifex` command that pulls translations from our [Transifex resource](https://www.transifex.com/projects/p/webmaker/resource/web-literacy-map/) and writes it to `locale/weblit/en_US.json`, `locale/weblit/es.json`, etc.
- [ ] Document `TRANSIFEX_USERPASS` and `gulp transifex` in our readme.
- [ ] Convert our web literacy page to retrieve its strings from a JSON message structure.
- [ ] Have our web literacy page dynamically pull its strings from locale-specific webpack bundles based on some kind of locale information ... ?
- [ ] profit
