### PR TITLE
Add front-end UI for club approval flow.

### DIFF
--- a/components/map.jsx
+++ b/components/map.jsx
@@ -9,6 +9,8 @@ var DEFAULT_STYLESHEETS = config.IN_TEST_SUITE ? [] : [
   'https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css',
   'https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css'
 ];
+var CLUB_PENDING_TEXT = "This club is pending approval and is not visible to other users.";
+var CLUB_DENIED_TEXT = "This club has been denied approval and is not visible to other users.";
 
 var mapboxId = process.env.MAPBOX_MAP_ID || 'alicoding.ldmhe4f3';
 var accessToken = process.env.MAPBOX_ACCESS_TOKEN || 'pk.eyJ1IjoiYWxpY29kaW5nIiwiYSI6Il90WlNFdE0ifQ.QGGdXGA_2QH-6ujyZE2oSg';
@@ -38,6 +40,7 @@ function geoJSONit(data) {
       "description": i.description,
       "website": i.website,
       "location": i.location,
+      "status": i.status,
       "title": i.name
     });
   });
@@ -77,6 +80,7 @@ var MarkerPopupClub = React.createClass({
   render: function() {
     var website = null;
     var actions = null;
+    var status = null;
 
     if (this.props.website) {
       website = (
@@ -84,6 +88,12 @@ var MarkerPopupClub = React.createClass({
           {this.getWebsiteDomain()}
         </a></p>
       );
+    }
+
+    if (this.props.status === 'pending') {
+      status = <span className="label label-warning" title={CLUB_PENDING_TEXT}>pending</span>;
+    } else if (this.props.status === 'denied') {
+      status = <span className="label label-danger" title={CLUB_DENIED_TEXT}>denied</span>;
     }
 
     if (this.props.isOwned) {
@@ -105,7 +115,7 @@ var MarkerPopupClub = React.createClass({
 
     return (
       <div>
-        <b>{this.props.title}<br/></b>
+        <b>{this.props.title} {status}<br/></b>
         <i>{this.props.location}</i>
         <br/>
         <br/>
@@ -129,6 +139,8 @@ var Map = React.createClass({
     onReady: React.PropTypes.func
   },
   statics: {
+    CLUB_PENDING_TEXT: CLUB_PENDING_TEXT,
+    CLUB_DENIED_TEXT: CLUB_DENIED_TEXT,
     MarkerPopup: MarkerPopup,
     clubsToGeoJSON: geoJSONit,
     setAccessToken: function(value) {

--- a/components/map.jsx
+++ b/components/map.jsx
@@ -9,8 +9,6 @@ var DEFAULT_STYLESHEETS = config.IN_TEST_SUITE ? [] : [
   'https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css',
   'https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css'
 ];
-var CLUB_PENDING_TEXT = "This club is pending approval and is not visible to other users.";
-var CLUB_DENIED_TEXT = "This club has been denied approval and is not visible to other users.";
 
 var mapboxId = process.env.MAPBOX_MAP_ID || 'alicoding.ldmhe4f3';
 var accessToken = process.env.MAPBOX_ACCESS_TOKEN || 'pk.eyJ1IjoiYWxpY29kaW5nIiwiYSI6Il90WlNFdE0ifQ.QGGdXGA_2QH-6ujyZE2oSg';
@@ -73,6 +71,40 @@ var MarkerPopup = React.createClass({
   }
 });
 
+var ClubStatusLabel = React.createClass({
+  propTypes: {
+    status: React.PropTypes.string.isRequired,
+    showApproved: React.PropTypes.bool
+  },
+  render: function() {
+    if (this.props.status === 'pending') {
+      return (
+        <span className="label label-warning"
+         title="This club is pending approval and is not visible to other users.">
+          pending
+        </span>
+      );
+    } else if (this.props.status === 'denied') {
+      return (
+        <span className="label label-danger"
+         title="This club has been denied approval and is not visible to other users.">
+          denied
+        </span>
+      );
+    }
+    if (this.props.showApproved) {
+      return (
+        <span className="label label-success"
+         title="This club has been approved and is visible to everyone.">
+          approved
+        </span>
+      );
+    } else {
+      return <span></span>;
+    }
+  }
+});
+
 var MarkerPopupClub = React.createClass({
   getWebsiteDomain: function() {
     return urlParse(this.props.website).hostname;
@@ -80,7 +112,6 @@ var MarkerPopupClub = React.createClass({
   render: function() {
     var website = null;
     var actions = null;
-    var status = null;
 
     if (this.props.website) {
       website = (
@@ -88,12 +119,6 @@ var MarkerPopupClub = React.createClass({
           {this.getWebsiteDomain()}
         </a></p>
       );
-    }
-
-    if (this.props.status === 'pending') {
-      status = <span className="label label-warning" title={CLUB_PENDING_TEXT}>pending</span>;
-    } else if (this.props.status === 'denied') {
-      status = <span className="label label-danger" title={CLUB_DENIED_TEXT}>denied</span>;
     }
 
     if (this.props.isOwned) {
@@ -115,7 +140,7 @@ var MarkerPopupClub = React.createClass({
 
     return (
       <div>
-        <b>{this.props.title} {status}<br/></b>
+        <b>{this.props.title} <ClubStatusLabel status={this.props.status}/><br/></b>
         <i>{this.props.location}</i>
         <br/>
         <br/>
@@ -139,8 +164,7 @@ var Map = React.createClass({
     onReady: React.PropTypes.func
   },
   statics: {
-    CLUB_PENDING_TEXT: CLUB_PENDING_TEXT,
-    CLUB_DENIED_TEXT: CLUB_DENIED_TEXT,
+    ClubStatusLabel: ClubStatusLabel,
     MarkerPopup: MarkerPopup,
     clubsToGeoJSON: geoJSONit,
     setAccessToken: function(value) {

--- a/components/map.jsx
+++ b/components/map.jsx
@@ -73,7 +73,11 @@ var MarkerPopup = React.createClass({
 
 var ClubStatusLabel = React.createClass({
   propTypes: {
-    status: React.PropTypes.string.isRequired,
+    status: React.PropTypes.oneOf([
+      'pending',
+      'approved',
+      'denied'
+    ]).isRequired,
     showApproved: React.PropTypes.bool
   },
   render: function() {

--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -28,6 +28,15 @@ function TeachAPI(options) {
     process.browser ? window.sessionStorage : {}
   );
   this._clubs = [];
+  this._clubsUpdateReq = null;
+  this.on('username:change', function() {
+    // The user changed, so if anyone is interested in clubs, we should
+    // automatically update those, since we don't want the old
+    // user's private clubs to be shown to the new user.
+    if (this.listeners('clubs:change').length) {
+      this.updateClubs();
+    }
+  }.bind(this));
 }
 
 TeachAPI.getDefaultURL = function() {
@@ -100,9 +109,13 @@ _.extend(TeachAPI.prototype, {
   },
   updateClubs: function(callback) {
     callback = callback || function () {};
-    return this.request('get', '/api/clubs/')
+    if (this._clubsUpdateReq) {
+      this._clubsUpdateReq.abort();
+    }
+    this._clubsUpdateReq = this.request('get', '/api/clubs/')
       .accept('json')
       .end(function(err, res) {
+        this._clubsUpdateReq = null;
         if (err) {
           return callback(err);
         }
@@ -110,6 +123,7 @@ _.extend(TeachAPI.prototype, {
         this.emit('clubs:change', res.body);
         callback(null, res.body);
       }.bind(this));
+    return this._clubsUpdateReq;
   },
   addClub: function(club, callback) {
     callback = callback || function () {};

--- a/pages/clubs.jsx
+++ b/pages/clubs.jsx
@@ -493,8 +493,8 @@ var ModalAddOrChangeYourClub = React.createClass({
           <p><img className="globe" src="/img/pages/clubs/svg/globe-with-pin.svg"/></p>
           {isAdd
            ? <div>
-               <h2>We've added your Club!</h2>
-               <p>Your club is now displayed on our map. Go ahead, take a look!</p>
+               <h2>Thanks for your submission!</h2>
+               <p>We&lsquo;ll review it and be in touch shortly. In the meantime, your club will only be visible to you.</p>
              </div>
            : <h2>Your club has been changed.</h2>}
           <button className="btn btn-block"

--- a/pages/clubs.jsx
+++ b/pages/clubs.jsx
@@ -19,9 +19,6 @@ var ga = require('react-ga');
 
 var Illustration = require('../components/illustration.jsx');
 
-var PENDING_TEXT = "This club is pending approval and is not visible to other users.";
-var DENIED_TEXT = "This club has been denied approval and is not visible to other users.";
-
 var ClubListItem = React.createClass({
   propTypes: {
     club: React.PropTypes.object.isRequired,
@@ -37,9 +34,9 @@ var ClubListItem = React.createClass({
     var ownerControls = null;
 
     if (club.status === 'pending') {
-      status = <div className="alert alert-warning">{PENDING_TEXT}</div>;
+      status = <div className="alert alert-warning">{Map.CLUB_PENDING_TEXT}</div>;
     } else if (club.status === 'denied') {
-      status = <div className="alert alert-danger">{DENIED_TEXT}</div>;
+      status = <div className="alert alert-danger">{Map.CLUB_DENIED_TEXT}</div>;
     }
 
     if (isOwned) {

--- a/pages/clubs.jsx
+++ b/pages/clubs.jsx
@@ -509,13 +509,16 @@ var ClubLists = React.createClass({
     onDelete: React.PropTypes.func.isRequired,
     onEdit: React.PropTypes.func.isRequired
   },
-  render: function() {
-    var username = this.props.username;
+  componentWillMount: function() {
+    this.componentWillReceiveProps(this.props);
+  },
+  componentWillReceiveProps: function(props) {
+    var username = props.username;
     var userClubs = [];
     var otherClubs = [];
     var userHasUnapprovedClubs = false;
 
-    this.props.clubs.forEach(function(club) {
+    props.clubs.forEach(function(club) {
       if (club.owner === username) {
         if (club.status !== 'approved') {
           userHasUnapprovedClubs = true;
@@ -526,17 +529,24 @@ var ClubLists = React.createClass({
       }
     });
 
+    this.setState({
+      userClubs: userClubs,
+      otherClubs: otherClubs,
+      userHasUnapprovedClubs: userHasUnapprovedClubs
+    });
+  },
+  render: function() {
     return (
       <div>
-        {userClubs.length ? (
+        {this.state.userClubs.length ? (
           <div>
             <h3>My Clubs</h3>
             <ClubList
-             clubs={userClubs}
-             username={username}
+             clubs={this.state.userClubs}
+             username={this.props.username}
              onDelete={this.props.onDelete}
              onEdit={this.props.onEdit}/>
-             {userHasUnapprovedClubs ? (
+             {this.state.userHasUnapprovedClubs ? (
                <div className="alert alert-warning">
                  <strong>Note:</strong> All clubs pending approval or denied are not visible to other users.
                </div>
@@ -544,7 +554,7 @@ var ClubLists = React.createClass({
           </div>
         ) : null}
         <h3>Club List</h3>
-        <ClubList clubs={otherClubs}/>
+        <ClubList clubs={this.state.otherClubs}/>
       </div>
     );
   }
@@ -559,6 +569,7 @@ var ClubsPage = React.createClass({
     normalizeClub: normalizeClub,
     validateClub: validateClub,
     ClubList: ClubList,
+    ClubLists: ClubLists,
     ModalAddOrChangeYourClub: ModalAddOrChangeYourClub,
     ModalRemoveYourClub: ModalRemoveYourClub,
     teachAPIEvents: {

--- a/pages/clubs.jsx
+++ b/pages/clubs.jsx
@@ -19,6 +19,9 @@ var ga = require('react-ga');
 
 var Illustration = require('../components/illustration.jsx');
 
+var PENDING_TEXT = "This club is pending approval and is not visible to other users.";
+var DENIED_TEXT = "This club has been denied approval and is not visible to other users.";
+
 var ClubListItem = React.createClass({
   propTypes: {
     club: React.PropTypes.object.isRequired,
@@ -30,7 +33,14 @@ var ClubListItem = React.createClass({
     var club = this.props.club;
     var clubName = club.website ? <a href={club.website}>{club.name}</a> : club.name;
     var isOwned = (club.owner === this.props.username);
+    var status = null;
     var ownerControls = null;
+
+    if (club.status === 'pending') {
+      status = <div className="alert alert-warning">{PENDING_TEXT}</div>;
+    } else if (club.status === 'denied') {
+      status = <div className="alert alert-danger">{DENIED_TEXT}</div>;
+    }
 
     if (isOwned) {
       ownerControls = (
@@ -52,6 +62,7 @@ var ClubListItem = React.createClass({
         <p><em>{club.location.split(',')[0]}</em></p>
         <p>{club.description}</p>
         <p><small>Led by <a href={"https://webmaker.org/en-US/search?type=user&q=" + club.owner}>{club.owner}</a></small></p>
+        {status}
         {ownerControls}
       </li>
     );

--- a/test/browser/clubs-page.test.jsx
+++ b/test/browser/clubs-page.test.jsx
@@ -97,6 +97,7 @@ describe("ClubsPage.ClubList", function() {
     owner: 'foo',
     website: 'http://example.org',
     location: 'Somewhere, USA',
+    status: 'approved',
     name: 'foo club'
   }];
 
@@ -119,6 +120,24 @@ describe("ClubsPage.ClubList", function() {
       );
       var btns = TestUtils.scryRenderedDOMComponentsWithTag(item, 'button');
       btns.length.should.equal(0);
+    });
+
+    it("shows pending info when status is pending", function() {
+      var item = TestUtils.renderIntoDocument(
+        <Item club={_.extend({}, clubs[0], {
+          status: 'pending'
+        })} onDelete={noop} onEdit={noop} />
+      );
+      item.getDOMNode().textContent.should.match(/pending/);
+    });
+
+    it("shows denied info when status is denied", function() {
+      var item = TestUtils.renderIntoDocument(
+        <Item club={_.extend({}, clubs[0], {
+          status: 'denied'
+        })} onDelete={noop} onEdit={noop} />
+      );
+      item.getDOMNode().textContent.should.match(/denied/);
     });
 
     describe("buttons", function() {

--- a/test/browser/clubs-page.test.jsx
+++ b/test/browser/clubs-page.test.jsx
@@ -88,6 +88,71 @@ describe("ClubsPage", function() {
   });
 });
 
+describe("ClubsPage.ClubLists", function() {
+  var ClubLists = ClubsPage.ClubLists;
+  var noop = function() {};
+  var clubs = [{
+    owner: 'foo',
+    website: 'http://example.org',
+    location: 'Somewhere, USA',
+    status: 'approved',
+    name: 'foo club'
+  }, {
+    owner: 'bar',
+    website: 'http://example.org/bar',
+    location: 'Somewhere Else, USA',
+    status: 'pending',
+    name: 'bar club'
+  }];
+
+  it("doesn't show 'My Clubs' when logged out", function() {
+    var lists = TestUtils.renderIntoDocument(
+      <ClubLists clubs={clubs} onDelete={noop} onEdit={noop}/>
+    );
+    lists.getDOMNode().textContent.should.not.match(/My Clubs/);
+  });
+
+  it("shows 'My Clubs' when logged-in user has clubs", function() {
+    var lists = TestUtils.renderIntoDocument(
+      <ClubLists clubs={clubs} onDelete={noop} onEdit={noop} username="foo"/>
+    );
+    lists.getDOMNode().textContent.should.match(/My Clubs/);
+  });
+
+  it("properly separates user's clubs from other clubs", function() {
+    var lists = TestUtils.renderIntoDocument(
+      <ClubLists clubs={clubs} onDelete={noop} onEdit={noop} username="foo"/>
+    );
+    lists.state.userClubs.should.eql([clubs[0]]);
+    lists.state.otherClubs.should.eql([clubs[1]]);
+  });
+
+  it("doesn't show note about unapproved clubs if there aren't any", function() {
+    var lists = TestUtils.renderIntoDocument(
+      <ClubLists clubs={clubs} onDelete={noop} onEdit={noop} username="foo"/>
+    );
+    lists.getDOMNode().textContent.should.not.match(/Note:/);
+    lists.state.userHasUnapprovedClubs.should.be.false;
+  });
+
+  it("shows note about unapproved clubs if there are any", function() {
+    var lists = TestUtils.renderIntoDocument(
+      <ClubLists clubs={clubs} onDelete={noop} onEdit={noop} username="bar"/>
+    );
+    lists.getDOMNode().textContent.should.match(/Note:/);
+    lists.state.userHasUnapprovedClubs.should.be.true;
+  });
+
+  it("updates its state when its props change", function() {
+    var lists = TestUtils.renderIntoDocument(
+      <ClubLists clubs={[]} onDelete={noop} onEdit={noop}/>
+    );
+    lists.state.userHasUnapprovedClubs.should.be.false;
+    lists.componentWillReceiveProps({ clubs: clubs, username: 'bar' });
+    lists.state.userHasUnapprovedClubs.should.be.true;
+  });
+});
+
 describe("ClubsPage.ClubList", function() {
   var ClubList = ClubsPage.ClubList;
   var Item = ClubList.Item;

--- a/test/browser/clubs-page.test.jsx
+++ b/test/browser/clubs-page.test.jsx
@@ -385,7 +385,7 @@ describe("ClubsPage.ModalAddOrChangeYourClub", function() {
         modal.state.networkError.should.be.false;
         modal.state.result.should.eql({url: 'http://foo'});
         modal.getDOMNode().textContent
-          .should.match(/your club is now displayed on our map/i);
+          .should.match(/thanks for your submission/i);
       });
 
       it("calls onSuccess when user clicks final button", function() {

--- a/test/browser/map.test.jsx
+++ b/test/browser/map.test.jsx
@@ -225,6 +225,36 @@ describe("Map.simplifyMapboxGeoJSON()", function() {
   });
 });
 
+describe("Map.ClubStatusLabel", function() {
+  it("is empty when status is approved and showApproved is false", function() {
+    var label = TestUtils.renderIntoDocument(
+      <Map.ClubStatusLabel status="approved" />
+    );
+    label.getDOMNode().textContent.should.equal('');
+  });
+
+  it("is 'approved' when status is approved and showApproved is true", function() {
+    var label = TestUtils.renderIntoDocument(
+      <Map.ClubStatusLabel status="approved" showApproved />
+    );
+    label.getDOMNode().textContent.should.equal('approved');
+  });
+
+  it("is 'denied' when status is denied", function() {
+    var label = TestUtils.renderIntoDocument(
+      <Map.ClubStatusLabel status="denied" />
+    );
+    label.getDOMNode().textContent.should.equal('denied');
+  });
+
+  it("is 'pending' when status is pending", function() {
+    var label = TestUtils.renderIntoDocument(
+      <Map.ClubStatusLabel status="pending" />
+    );
+    label.getDOMNode().textContent.should.equal('pending');
+  });
+});
+
 describe("Map.getAutocompleteOptions()", function() {
   var xhr, requests;
 

--- a/test/browser/map.test.jsx
+++ b/test/browser/map.test.jsx
@@ -14,6 +14,7 @@ var SAMPLE_FOO_CLUB = {
   description: 'my club',
   website: 'http://example.org/',
   location: 'fooville',
+  status: 'approved',
   name: 'my club'
 };
 
@@ -25,6 +26,7 @@ var SAMPLE_BAR_CLUB = {
   description: 'bar club',
   website: 'http://example.org/bar',
   location: 'barville',
+  status: 'approved',
   name: 'bar club'
 };
 
@@ -129,6 +131,22 @@ describe("Map.MarkerPopup", function() {
     findButtons(popup).length.should.equal(2);
   });
 
+  it("should show when club is pending", function() {
+    var club = _.extend({}, SAMPLE_FOO_CLUB, {status: 'pending'});
+    var popup = TestUtils.renderIntoDocument(
+      <Map.MarkerPopup clubs={[club]} username="bar" />
+    );
+    popup.getDOMNode().textContent.should.match(/pending/);
+  });
+
+  it("should show when club is denied", function() {
+    var club = _.extend({}, SAMPLE_FOO_CLUB, {status: 'denied'});
+    var popup = TestUtils.renderIntoDocument(
+      <Map.MarkerPopup clubs={[club]} username="bar" />
+    );
+    popup.getDOMNode().textContent.should.match(/denied/);
+  });
+
   it("should not show website when it is blank", function() {
     var club = _.extend({}, SAMPLE_FOO_CLUB, {website: ''});
     var popup = TestUtils.renderIntoDocument(
@@ -157,6 +175,7 @@ describe("Map.clubsToGeoJSON()", function() {
       }, properties: {
         clubs: [{
           url: 'http://server/clubs/1/',
+          status: 'approved',
           owner: 'foo',
           description: 'my club',
           website: 'http://example.org/',

--- a/test/browser/teach-api.test.js
+++ b/test/browser/teach-api.test.js
@@ -157,6 +157,26 @@ describe('TeachAPI', function() {
       });
     });
 
+    it('aborts earlier in-progress calls', function() {
+      api.updateClubs();
+      api.updateClubs();
+      requests.length.should.equal(2);
+      requests[0].aborted.should.be.true;
+    });
+
+    it('is not called when username changes, no club listeners', function() {
+      api.updateClubs = sinon.spy();
+      api.emit('username:change');
+      api.updateClubs.callCount.should.equal(0);
+    });
+
+    it('is called when username changes, club listeners exist', function() {
+      api.updateClubs = sinon.spy();
+      api.on('clubs:change', function() {});
+      api.emit('username:change');
+      api.updateClubs.callCount.should.equal(1);
+    });
+
     it('accesses /api/clubs/', function() {
       api.updateClubs();
       requests.length.should.equal(1);


### PR DESCRIPTION
When finished, this will fix #920 and #911.

When a user creates a new club, the success message now looks like this:


![2015-06-01_11-57-16](https://cloud.githubusercontent.com/assets/124687/7917104/dc2113f0-0855-11e5-87d2-768a09c0e49d.jpg)

Approved, pending, and denied clubs look like this in the club list, which now has a separate section for the current user's clubs:

![teach-clubs-feedback](https://cloud.githubusercontent.com/assets/2492510/7925798/0cdd1b7e-087e-11e5-857b-51ba12ef027a.png)

The map popup also reflects the club pending/denied status through a Bootstrap label, with more detail provided via the `title` attribute:

![2015-06-01_13-35-06](https://cloud.githubusercontent.com/assets/124687/7919012/6a103b34-0863-11e5-96e5-67a35954368b.jpg)


Still to do:
- [X] Add pending/denied information to the club list.
- [x] Add pending/denied information to the map pop-up information.
- [x] Modify the club submission success message (#920).
- [x] Add tests for `ClubStatusLabel `.
- [x] Add tests for `ClubLists`.
- [x] There's a bug where logging out will still show the unapproved clubs for the previous user. This is because our existing code assumes that the club list won't change when the current user changes; however, this assumption is broken with the club approval flow changes, so we need to account for that.