### PR TITLE
Fixes #544 - change CTA copy on Teach Like Mozilla page

### DIFF
--- a/pages/teach-like-mozilla.jsx
+++ b/pages/teach-like-mozilla.jsx
@@ -58,9 +58,9 @@ var TeachLikeMozillaPage = React.createClass({
               <IconLink
                 linkTo="web-literacy"
                 imgSrc="/img/pages/teach-like-mozilla/svg/icon-learn.svg"
-                imgAlt="icon learn"
-                head="Learn"
-                subhead="See our Web Literacy Map"
+                imgAlt="icon understand"
+                head="Understand"
+                subhead="Learn more about the Web Literacy Map"
               />
               <IconLink
                 href="http://discourse.webmaker.org/category/meet"


### PR DESCRIPTION
This fixes #544 

 - [x] Rename the "Learn" CTA to "Understand"
 - [x] Change sub-copy to "Learn more about the Web Literacy Map"


Note that I will tackle the [`imgAlt` `prop` removal work](https://github.com/mozilla/teach.webmaker.org/issues/906) in another PR.