### PR TITLE
Use google blog feed loader on homepage.

### DIFF
--- a/lib/blog-feed-loader.js
+++ b/lib/blog-feed-loader.js
@@ -1,2 +1,0 @@
-// TODO: Replace this with a real implementation.
-module.exports = require('../test/browser/stub-blog-feed-loader');

--- a/pages/home.jsx
+++ b/pages/home.jsx
@@ -12,7 +12,7 @@ var IconButtons = require('../components/icon-buttons.jsx');
 var IconButton = require('../components/icon-button.jsx');
 
 var config = require('../lib/config');
-var loadBlogPosts = require('../lib/blog-feed-loader');
+var loadBlogPosts = require('../lib/google-blog-feed-loader');
 
 var CaseStudies = React.createClass({
   render: function() {
@@ -109,7 +109,7 @@ var BlogSection = React.createClass({
         return;
       }
       this.setState({
-        featuredPost: data.featuredPosts,
+        featuredPost: data.featuredPost,
         latestPosts: data.latestPosts
       });
     }.bind(this));


### PR DESCRIPTION
Oof. In #950 we added the Google blog feed loader but forgot to actually hook it up to the homepage! This does that, and fixes #963.

@mmmavis can you review real quick?