### PR TITLE
Use google blog feed loader on homepage.

### DIFF
--- a/lib/blog-feed-loader.js
+++ b/lib/blog-feed-loader.js
@@ -1,2 +1,6 @@
-// TODO: Replace this with a real implementation.
-module.exports = require('../test/browser/stub-blog-feed-loader');
+if (process.env.NODE_ENV !== 'production' &&
+    require('./config').IN_TEST_SUITE) {
+  module.exports = require('../test/browser/stub-blog-feed-loader');
+} else {
+  module.exports = require('./google-blog-feed-loader');
+}

--- a/pages/home.jsx
+++ b/pages/home.jsx
@@ -109,7 +109,7 @@ var BlogSection = React.createClass({
         return;
       }
       this.setState({
-        featuredPost: data.featuredPosts,
+        featuredPost: data.featuredPost,
         latestPosts: data.latestPosts
       });
     }.bind(this));

--- a/test/browser/stub-blog-feed-loader.js
+++ b/test/browser/stub-blog-feed-loader.js
@@ -1,5 +1,5 @@
 var FAKE_POSTS = {
-  "featuredPosts": {
+  "featuredPost": {
     "title": "What’s next for Thimble?",
     "author": "Hannah Kane",
     "publishedDate": "Tue, 12 May 2015 10:47:33 -0700",


### PR DESCRIPTION
In #950 we added the Google blog feed loader but didn't hook it up to the homepage.

I attempted to do that in #972 but messed up.

This hopefully gets it right and fixes #963.