### PR TITLE
Only emit "username:change" when the username actually changes.

### DIFF
--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -38,8 +38,13 @@ util.inherits(TeachAPI, EventEmitter);
 
 _.extend(TeachAPI.prototype, {
   logout: function() {
+    var currentUsername = this.getUsername();
+
     delete this.storage[STORAGE_KEY];
-    this.emit('username:change', null);
+
+    if (currentUsername !== null) {
+      this.emit('username:change', null);
+    }
     this.emit('logout');
   },
   getLoginInfo: function() {
@@ -55,7 +60,7 @@ _.extend(TeachAPI.prototype, {
   },
   getUsername: function() {
     var info = this.getLoginInfo();
-    return info && info.username;
+    return info && (info.username || null);
   },
   checkLoginStatus: function() {
     this.emit('login:start');
@@ -63,15 +68,19 @@ _.extend(TeachAPI.prototype, {
       .withCredentials()
       .accept('json')
       .end(function(err, res) {
+        var currentUsername;
         if (err) {
           this.emit('login:error', err);
           return;
         }
         if (res.body.username) {
+          currentUsername = this.getUsername();
           // TODO: Handle a thrown exception here.
           this.storage[STORAGE_KEY] = JSON.stringify(res.body);
 
-          this.emit('username:change', res.body.username);
+          if (res.body.username !== currentUsername) {
+            this.emit('username:change', res.body.username);
+          }
           this.emit('login:success', res.body);
         } else {
           this.logout();

--- a/test/browser/teach-api.test.js
+++ b/test/browser/teach-api.test.js
@@ -22,11 +22,21 @@ describe('TeachAPI', function() {
   it('emits username:change event on logout', function(done) {
     var api = new TeachAPI({storage: storage});
 
+    storage['TEACH_API_LOGIN_INFO'] = '{"username": "bop"}';
     api.on('username:change', function(username) {
       should(username).equal(null);
       done();
     });
     api.logout();
+  });
+
+  it('emits no username:change on logout when unchanged', function() {
+    var api = new TeachAPI({storage: storage});
+    var eventFired = false;
+
+    api.on('username:change', function(username) { eventFired = true; });
+    api.logout();
+    eventFired.should.be.false;
   });
 
   it('clears storage on logout', function(done) {
@@ -379,6 +389,30 @@ describe('TeachAPI', function() {
         JSON.parse(storage['TEACH_API_LOGIN_INFO'])
           .should.eql(loginInfo);
         usernameEventEmitted.should.be.true;
+        done();
+      });
+
+      requests[0].respond(200, {
+        'Content-Type': 'application/json'
+      }, JSON.stringify(loginInfo));
+    });
+
+    it('only emits username:change on login if changed', function(done) {
+      var usernameEventEmitted = false;
+      var api = new TeachAPI({storage: storage});
+      var loginInfo = {
+        'username': 'foo',
+        'token': 'blah'
+      };
+
+      storage['TEACH_API_LOGIN_INFO'] = JSON.stringify(loginInfo);
+      api.checkLoginStatus();
+
+      api.on('username:change', function(username) {
+        usernameEventEmitted = true;
+      });
+      api.on('login:success', function() {
+        usernameEventEmitted.should.be.false;
         done();
       });
 


### PR DESCRIPTION
In #965 I changed the behavior of TeachAPI so it re-triggers fetching of clubs whenever the current user changes, but the `username:change` event is actually fired when the current user *doesn't* change, which ultimately results in spurious re-fetches of the club list.

This fixes things so the `username:change` event is only fired when the current username *actually* changes.