### PR TITLE
Add permalinks for Web Literacy Map expander sections

### DIFF
--- a/components/expander.jsx
+++ b/components/expander.jsx
@@ -43,16 +43,20 @@ var Expander = React.createClass({
   },
   handleHashChange: function() {
     if (window.location.hash === '#' + this.props.id) {
-      this.setState({
-        expanded: true,
-        attractAttention: true
-      });
-      this.attractTimeout = window.setTimeout(this.cancelAttractAttention,
-                                              ATTRACT_ATTENTION_DURATION);
+      this.attractAttention();
       this.refs.header.getDOMNode().focus();
     } else if (this.state.attractAttention) {
       this.cancelAttractAttention();
     }
+  },
+  attractAttention: function() {
+    this.setState({
+      expanded: true,
+      attractAttention: true
+    });
+    window.clearTimeout(this.attractTimeout);
+    this.attractTimeout = window.setTimeout(this.cancelAttractAttention,
+                                            ATTRACT_ATTENTION_DURATION);
   },
   cancelAttractAttention: function() {
     window.clearTimeout(this.attractTimeout);
@@ -71,8 +75,8 @@ var Expander = React.createClass({
     if (e.which === 9) {
       // We've just been focused via the keyboard. Toggling the content
       // is annoying to fiddle with via pure keyboard navigation, so just
-      // expand our content.
-      this.expand();
+      // expand our content and attract attention to it.
+      this.attractAttention();
     }
   },
   render: function() {

--- a/components/expander.jsx
+++ b/components/expander.jsx
@@ -6,7 +6,13 @@ var Expander = React.createClass({
       expanded: false
     };
   },
-  collapse: function() {
+  componentDidMount: function() {
+    if (this.props.id && window.location.hash === '#' + this.props.id) {
+      this.expand();
+      this.refs.header.getDOMNode().focus();
+    }
+  },
+  collapse: function(e) {
     this.setState({
       expanded: false
     });
@@ -22,7 +28,12 @@ var Expander = React.createClass({
     } else {
       this.expand();
     }
-    e.preventDefault();
+  },
+  handleKeyUp: function() {
+    // We've just been focused via the keyboard. Toggling the content
+    // is annoying to fiddle with via pure keyboard navigation, so just
+    // expand our content.
+    this.expand();
   },
   render: function() {
     var className = "expand-div";
@@ -31,12 +42,19 @@ var Expander = React.createClass({
     }
     return (
       <div className="expander-container">
-        <div className={className} tabIndex="0" onBlur={this.collapse} onFocus={this.expand}>
-          <h4 onMouseDown={this.handleMouseDown} className="expander-header">
+        <div className={className}>
+          <h4 ref="header" className="expander-header" id={this.props.id}
+           tabIndex="0" onKeyUp={this.handleKeyUp}
+           onMouseDown={this.handleMouseDown}>
             {this.props.head}
             <span className="ion"></span>
           </h4>
-          <div className="expander-items-container">
+          <div className="expander-items-container" onFocus={this.expand}>
+            {this.props.id
+             ? <a className="expander-permalink"
+                href={"#" + this.props.id}
+                title="Permalink to this section">&sect;</a>
+             : null}
             <div className="items-margin">
               {this.props.children}
             </div>

--- a/components/expander.jsx
+++ b/components/expander.jsx
@@ -50,11 +50,13 @@ var Expander = React.createClass({
       this.expand();
     }
   },
-  handleKeyUp: function() {
-    // We've just been focused via the keyboard. Toggling the content
-    // is annoying to fiddle with via pure keyboard navigation, so just
-    // expand our content.
-    this.expand();
+  handleKeyUp: function(e) {
+    if (e.which === 9) {
+      // We've just been focused via the keyboard. Toggling the content
+      // is annoying to fiddle with via pure keyboard navigation, so just
+      // expand our content.
+      this.expand();
+    }
   },
   render: function() {
     var className = "expand-div";

--- a/components/expander.jsx
+++ b/components/expander.jsx
@@ -31,7 +31,7 @@ var Expander = React.createClass({
     }
   },
   handleKeyUp: function(e) {
-    if (e.which === 9 && this.props.anchorId) {
+    if (e.which === 9) {
       // We've just been focused via the keyboard. Toggling the content
       // is annoying to fiddle with via pure keyboard navigation, so just
       // expand our content and attract attention to it.

--- a/components/expander.jsx
+++ b/components/expander.jsx
@@ -21,6 +21,7 @@ var Expander = React.createClass({
   },
   handleAttractAttentionToAnchor: function() {
     this.expand();
+    this.refs.header.getDOMNode().focus();
   },
   handleMouseDown: function(e) {
     if (this.state.expanded) {
@@ -30,7 +31,7 @@ var Expander = React.createClass({
     }
   },
   handleKeyUp: function(e) {
-    if (e.which === 9) {
+    if (e.which === 9 && this.props.anchorId) {
       // We've just been focused via the keyboard. Toggling the content
       // is annoying to fiddle with via pure keyboard navigation, so just
       // expand our content and attract attention to it.

--- a/components/expander.jsx
+++ b/components/expander.jsx
@@ -1,35 +1,13 @@
 var React = require('react');
 
-var ATTRACT_ATTENTION_DURATION = 4000;
+var AnchorManagerMixin = require('../mixins/anchor-manager');
 
 var Expander = React.createClass({
-  propTypes: {
-    id: React.PropTypes.string
-  },
+  mixins: [AnchorManagerMixin],
   getInitialState: function() {
     return {
-      expanded: false,
-      attractAttention: false
+      expanded: false
     };
-  },
-  componentDidMount: function() {
-    if (this.props.id) {
-      window.addEventListener('hashchange', this.handleHashChange);
-      this.handleHashChange();
-    }
-  },
-  componentWillUnmount: function() {
-    if (this.props.id) {
-      window.removeEventListener('hashchange', this.handleHashChange);
-    }
-    this.cancelAttractAttention();
-  },
-  componentDidUpdate: function(prevProps) {
-    if (process.env.NODE_ENV !== 'production') {
-      if (prevProps.id !== this.props.id) {
-        console.warn('"id" prop is expected to be constant, but changed.');
-      }
-    }
   },
   collapse: function(e) {
     this.setState({
@@ -41,28 +19,8 @@ var Expander = React.createClass({
       expanded: true
     });
   },
-  handleHashChange: function() {
-    if (window.location.hash === '#' + this.props.id) {
-      this.attractAttention();
-      this.refs.header.getDOMNode().focus();
-    } else if (this.state.attractAttention) {
-      this.cancelAttractAttention();
-    }
-  },
-  attractAttention: function() {
-    this.setState({
-      expanded: true,
-      attractAttention: true
-    });
-    window.clearTimeout(this.attractTimeout);
-    this.attractTimeout = window.setTimeout(this.cancelAttractAttention,
-                                            ATTRACT_ATTENTION_DURATION);
-  },
-  cancelAttractAttention: function() {
-    window.clearTimeout(this.attractTimeout);
-    this.setState({
-      attractAttention: false
-    });
+  handleAttractAttentionToAnchor: function() {
+    this.expand();
   },
   handleMouseDown: function(e) {
     if (this.state.expanded) {
@@ -76,7 +34,7 @@ var Expander = React.createClass({
       // We've just been focused via the keyboard. Toggling the content
       // is annoying to fiddle with via pure keyboard navigation, so just
       // expand our content and attract attention to it.
-      this.attractAttention();
+      this.attractAttentionToAnchor();
     }
   },
   render: function() {
@@ -84,22 +42,23 @@ var Expander = React.createClass({
     if (this.state.expanded) {
       className += " expanded";
     }
-    if (this.state.attractAttention) {
+    if (this.state.attractAttentionToAnchor) {
       className += " attract-attention";
     }
     return (
       <div className="expander-container">
         <div className={className}>
-          <h4 ref="header" className="expander-header" id={this.props.id}
+          <h4 ref="header" className="expander-header"
+           id={this.props.anchorId}
            tabIndex="0" onKeyUp={this.handleKeyUp}
            onMouseDown={this.handleMouseDown}>
             {this.props.head}
             <span className="ion"></span>
           </h4>
           <div className="expander-items-container" onFocus={this.expand}>
-            {this.props.id
+            {this.props.anchorId
              ? <a className="expander-permalink"
-                href={"#" + this.props.id}
+                href={"#" + this.props.anchorId}
                 title="Permalink to this section">&sect;</a>
              : null}
             <div className="items-margin">

--- a/components/expander.jsx
+++ b/components/expander.jsx
@@ -1,15 +1,30 @@
 var React = require('react');
 
 var Expander = React.createClass({
+  propTypes: {
+    id: React.PropTypes.string
+  },
   getInitialState: function() {
     return {
       expanded: false
     };
   },
   componentDidMount: function() {
-    if (this.props.id && window.location.hash === '#' + this.props.id) {
-      this.expand();
-      this.refs.header.getDOMNode().focus();
+    if (this.props.id) {
+      window.addEventListener('hashchange', this.handleHashChange);
+      this.handleHashChange();
+    }
+  },
+  componentWillUnmount: function() {
+    if (this.props.id) {
+      window.removeEventListener('hashchange', this.handleHashChange);
+    }
+  },
+  componentDidUpdate: function(prevProps) {
+    if (process.env.NODE_ENV !== 'production') {
+      if (prevProps.id !== this.props.id) {
+        console.warn('"id" prop is expected to be constant, but changed.');
+      }
     }
   },
   collapse: function(e) {
@@ -21,6 +36,12 @@ var Expander = React.createClass({
     this.setState({
       expanded: true
     });
+  },
+  handleHashChange: function() {
+    if (window.location.hash === '#' + this.props.id) {
+      this.expand();
+      this.refs.header.getDOMNode().focus();
+    }
   },
   handleMouseDown: function(e) {
     if (this.state.expanded) {

--- a/components/expander.jsx
+++ b/components/expander.jsx
@@ -1,12 +1,15 @@
 var React = require('react');
 
+var ATTRACT_ATTENTION_DURATION = 4000;
+
 var Expander = React.createClass({
   propTypes: {
     id: React.PropTypes.string
   },
   getInitialState: function() {
     return {
-      expanded: false
+      expanded: false,
+      attractAttention: false
     };
   },
   componentDidMount: function() {
@@ -19,6 +22,7 @@ var Expander = React.createClass({
     if (this.props.id) {
       window.removeEventListener('hashchange', this.handleHashChange);
     }
+    this.cancelAttractAttention();
   },
   componentDidUpdate: function(prevProps) {
     if (process.env.NODE_ENV !== 'production') {
@@ -39,9 +43,22 @@ var Expander = React.createClass({
   },
   handleHashChange: function() {
     if (window.location.hash === '#' + this.props.id) {
-      this.expand();
+      this.setState({
+        expanded: true,
+        attractAttention: true
+      });
+      this.attractTimeout = window.setTimeout(this.cancelAttractAttention,
+                                              ATTRACT_ATTENTION_DURATION);
       this.refs.header.getDOMNode().focus();
+    } else if (this.state.attractAttention) {
+      this.cancelAttractAttention();
     }
+  },
+  cancelAttractAttention: function() {
+    window.clearTimeout(this.attractTimeout);
+    this.setState({
+      attractAttention: false
+    });
   },
   handleMouseDown: function(e) {
     if (this.state.expanded) {
@@ -62,6 +79,9 @@ var Expander = React.createClass({
     var className = "expand-div";
     if (this.state.expanded) {
       className += " expanded";
+    }
+    if (this.state.attractAttention) {
+      className += " attract-attention";
     }
     return (
       <div className="expander-container">

--- a/components/expander.jsx
+++ b/components/expander.jsx
@@ -4,12 +4,15 @@ var AnchorManagerMixin = require('../mixins/anchor-manager');
 
 var Expander = React.createClass({
   mixins: [AnchorManagerMixin],
+  propTypes: {
+    head: React.PropTypes.node.isRequired
+  },
   getInitialState: function() {
     return {
       expanded: false
     };
   },
-  collapse: function(e) {
+  collapse: function() {
     this.setState({
       expanded: false
     });

--- a/less/components/expander.less
+++ b/less/components/expander.less
@@ -51,6 +51,15 @@ html.no-js {
       }
     }
   }
+  .expand-div.expanded.attract-attention .expander-items-container {
+    animation-name: attract;
+    animation-duration: 4s;
+  }
+  @keyframes attract {
+    from {
+      background: orange;
+    }
+  }
   .expander-items-container {
     position: relative;
     text-align: left;

--- a/less/components/expander.less
+++ b/less/components/expander.less
@@ -1,7 +1,6 @@
 html.no-js {
   .expander-container {
     .expand-div {
-      outline: 0;
       .ion {
         display: none;
       }
@@ -32,10 +31,15 @@ html.no-js {
       }
     }
   }
+  .expander-header:focus {
+    /* Keyboard focus for this element doesn't mean anything for the
+     * UI, because we instantly expand the section as soon as we
+     * notice that it's been focused via the keyboard. */
+    outline: none;
+  }
   .expand-div {
     border-top: .2rem solid #fff;
     &.expanded {
-      outline: 0;
       .ion {
         &:before {
           content: "\f126";
@@ -48,6 +52,7 @@ html.no-js {
     }
   }
   .expander-items-container {
+    position: relative;
     text-align: left;
     overflow: hidden;
     max-height: 0;
@@ -60,5 +65,11 @@ html.no-js {
       line-height: 2.2rem;
       font-weight: 400;
     }
+  }
+  .expander-permalink {
+    opacity: 0.66;
+    position: absolute;
+    right: 0.25rem;
+    top: 0.25rem;
   }
 }

--- a/mixins/anchor-manager.js
+++ b/mixins/anchor-manager.js
@@ -1,0 +1,90 @@
+// AnchorManagerMixin is a React mixin that can be used to make the
+// component support permalinkable anchors (URL fragments) that
+// attract the user's attention to them when navigated to.
+//
+// Any component that uses this mixin supports an `anchorId` prop,
+// which is the URL fragment (without the leading hash) of the anchor.
+// This is expected to be constant throughout the lifetime of the
+// component. (If `anchorId` is undefined, the mixin will be disabled.)
+//
+// When the window's location hash matches the component's anchor id,
+// either at component mount time or during the `hashchange` window
+// event, the component's `attractAttentionToAnchor` state will be
+// set to `true` for 4 seconds. Additionally, if the component
+// defines a `handleAttractAttentionToAnchor` method, it will be
+// called.
+//
+// The 4-second default can be changed if the component defines
+// an instance variable called `ATTRACT_ATTENTION_TO_ANCHOR_DURATION`,
+// which should be set to an integer value in milliseconds.
+//
+// Note that this mixin will *not* directly affect the component's
+// rendering in any way. This means that it is not responsible for e.g.:
+//
+// * Setting any CSS classes, transitions, or animations.
+// * Setting the `id` attribute of any elements.
+// * Creating permalinks.
+
+var React = require('react');
+
+var DEFAULT_ATTRACT_DURATION = 4000;
+
+var AnchorManagerMixin = {
+  propTypes: {
+    anchorId: React.PropTypes.string
+  },
+  getInitialState: function() {
+    return {
+      attractAttentionToAnchor: false
+    };
+  },
+  componentDidMount: function() {
+    if (this.props.anchorId) {
+      window.addEventListener('hashchange', this.handleHashChange);
+      this.handleHashChange();
+    }
+  },
+  componentWillUnmount: function() {
+    if (this.props.anchorId) {
+      window.removeEventListener('hashchange', this.handleHashChange);
+    }
+    this.cancelAttractAttentionToAnchor();
+  },
+  componentDidUpdate: function(prevProps) {
+    if (process.env.NODE_ENV !== 'production') {
+      if (prevProps.anchorId !== this.props.anchorId) {
+        console.warn('"anchorId" prop is expected to be constant, ' +
+                     'but changed.');
+      }
+    }
+  },
+  handleHashChange: function() {
+    if (window.location.hash === '#' + this.props.anchorId) {
+      this.attractAttentionToAnchor();
+      this.refs.header.getDOMNode().focus();
+    } else if (this.state.attractAttentionToAnchor) {
+      this.cancelAttractAttentionToAnchor();
+    }
+  },
+  attractAttentionToAnchor: function() {
+    this.setState({
+      attractAttentionToAnchor: true
+    });
+    window.clearTimeout(this.attractTimeout);
+    this.attractTimeout = window.setTimeout(
+      this.cancelAttractAttentionToAnchor,
+      this.ATTRACT_ATTENTION_TO_ANCHOR_DURATION || DEFAULT_ATTRACT_DURATION
+    );
+    if (typeof(this.handleAttractAttentionToAnchor) === 'function') {
+      this.handleAttractAttentionToAnchor();
+    }
+  },
+  cancelAttractAttentionToAnchor: function() {
+    window.clearTimeout(this.attractTimeout);
+    this.setState({
+      attractAttentionToAnchor: false
+    });
+  }
+};
+
+module.exports = AnchorManagerMixin;

--- a/mixins/anchor-manager.js
+++ b/mixins/anchor-manager.js
@@ -119,7 +119,6 @@ var AnchorManagerMixin = {
   },
   handleNavigateToAnchor: function() {
     this.attractAttentionToAnchor();
-    this.refs.header.getDOMNode().focus();
   },
   handleNavigateFromAnchor: function() {
     this.cancelAttractAttentionToAnchor();
@@ -154,6 +153,7 @@ if (process.env.NODE_ENV !== 'production') {
   };
   if (require('../lib/config').IN_TEST_SUITE) {
     AnchorManagerMixin.AnchorManager = AnchorManager;
+    AnchorManagerMixin.DEFAULT_ATTRACT_DURATION = DEFAULT_ATTRACT_DURATION;
   }
 }
 

--- a/mixins/anchor-manager.js
+++ b/mixins/anchor-manager.js
@@ -5,14 +5,16 @@
 // Any component that uses this mixin supports an `anchorId` prop,
 // which is the URL fragment (without the leading hash) of the anchor.
 // This is expected to be constant throughout the lifetime of the
-// component. (If `anchorId` is undefined, the mixin will be disabled.)
+// component. (If `anchorId` is undefined, the mixin will be largely
+// disabled.)
 //
 // When the window's location hash matches the component's anchor id,
 // either at component mount time or during the `hashchange` window
 // event, the component's `attractAttentionToAnchor` state will be
 // set to `true` for 4 seconds. Additionally, if the component
 // defines a `handleAttractAttentionToAnchor` method, it will be
-// called.
+// called. (The `attractAttentionToAnchor` method can be used to
+// manually trigger this behavior as well.)
 //
 // The 4-second default can be changed if the component defines
 // an instance variable called `ATTRACT_ATTENTION_TO_ANCHOR_DURATION`,
@@ -29,6 +31,13 @@ var React = require('react');
 
 var DEFAULT_ATTRACT_DURATION = 4000;
 
+// AnchorManager is a largely private singleton class that maintains a
+// registry mapping anchor names to React components and listens for
+// location hash changes.
+//
+// When a registered component needs to be navigated to, its
+// `handleNavigateToAnchor` method is called; when it needs to
+// be navigated from, its `handleNavigateFromAnchor` method is called.
 var AnchorManager = function() {
   this.anchorMap = {};
   this.initialized = false;

--- a/mixins/anchor-manager.js
+++ b/mixins/anchor-manager.js
@@ -49,6 +49,7 @@ AnchorManager.prototype = {
       this.initialized = true;
     }
     this.handleHashChange();
+    return component;
   },
   unregister: function(component) {
     var anchorId = component.props.anchorId;

--- a/pages/web-literacy.jsx
+++ b/pages/web-literacy.jsx
@@ -49,7 +49,7 @@ var ActivitiesPage = React.createClass({
         <section>
           <WebMaps>
             <WebMap head="Explore" subhead="Reading the Web">
-              <Expander head="navigation">
+              <Expander head="navigation" id="navigation">
                 <ul>
                   <li>Accessing the web using the common features of a browser.</li>
                   <li>Using hyperlinks to access a range of resources on the web.</li>
@@ -58,7 +58,7 @@ var ActivitiesPage = React.createClass({
                   <li>Exploring browser add-ons and extensions to provide additional functionality.</li>
                 </ul>
               </Expander>
-              <Expander head="web mechanics">
+              <Expander head="web mechanics" id="web-mechanics">
                 <ul>
                   <li>Using and understanding the differences between URLs, IP addresses and search terms.</li>
                   <li>Identifying where data is in the network of devices that makes up the Internet.</li>
@@ -67,7 +67,7 @@ var ActivitiesPage = React.createClass({
                   <li>Creating or modifying an algorithm to serve content from around the web.</li>
                 </ul>
               </Expander>
-              <Expander head="search">
+              <Expander head="search" id="search">
                 <ul>
                   <li>Developing questions to aid a search.</li>
                   <li>Using and revising keywords to make web searches more efficient.</li>
@@ -76,7 +76,7 @@ var ActivitiesPage = React.createClass({
                   <li>Discovering information and resources by asking people within social networks.</li>
                 </ul>
               </Expander>
-              <Expander head="credibility">
+              <Expander head="credibility" id="credibility">
                 <ul>
                   <li>Comparing and contrasting information from a number of sources.</li>
                   <li>Making judgments based on technical and design characteristics.</li>
@@ -85,7 +85,7 @@ var ActivitiesPage = React.createClass({
                   <li>Evaluating how purpose and perspectives shape web resources.</li>
                 </ul>
               </Expander>
-              <Expander head="security">
+              <Expander head="security" id="security">
                 <ul>
                   <li>Recommending how to avoid online scams and 'phishing’.</li>
                   <li>Managing and maintaining account security.</li>
@@ -95,7 +95,7 @@ var ActivitiesPage = React.createClass({
               </Expander>
             </WebMap>
             <WebMap head="Build" subhead="Writing the Web">
-              <Expander head="composing">
+              <Expander head="composing" id="composing">
                 <ul>
                   <li>Inserting hyperlinks into a web page.</li>
                   <li>Identifying and using HTML tags.</li>
@@ -104,7 +104,7 @@ var ActivitiesPage = React.createClass({
                   <li>Setting up and controlling a space to publish on the Web.</li>
                 </ul>
               </Expander>
-              <Expander head="remixing">
+              <Expander head="remixing" id="remixing">
                 <ul>
                   <li>Identifying remixable content.</li>
                   <li>Combining multimedia resources to create something new on the web.</li>
@@ -112,7 +112,7 @@ var ActivitiesPage = React.createClass({
                   <li>Citing and referencing original content.</li>
                 </ul>
               </Expander>
-              <Expander head="designing">
+              <Expander head="designing" id="designing">
                 <ul>
                   <li>Using CSS properties to change the style and layout of a Web page.</li>
                   <li>Demonstrating the difference between inline, embedded and external CSS.</li>
@@ -120,7 +120,7 @@ var ActivitiesPage = React.createClass({
                   <li>Creating device-agnostic web resources.</li>
                 </ul>
               </Expander>
-              <Expander head="coding/scripting">
+              <Expander head="coding/scripting" id="coding-scripting">
                 <ul>
                   <li>Reading and explaining the structure of code.</li>
                   <li>Identifying and applying common coding patterns and concepts.</li>
@@ -129,7 +129,7 @@ var ActivitiesPage = React.createClass({
                   <li>Querying a web service using an API.</li>
                 </ul>
               </Expander>
-              <Expander head="accessibility">
+              <Expander head="accessibility" id="accessibility">
                 <ul>
                   <li>Using empathy and awareness to inform the design of web content that is accessible to all users.</li>
                   <li>Designing for different cultures which may have different interpretations of design elements.</li>
@@ -140,7 +140,7 @@ var ActivitiesPage = React.createClass({
               </Expander>
             </WebMap>
             <WebMap head="Connect" subhead="Participating on the Web">
-              <Expander head="sharing">
+              <Expander head="sharing" id="sharing">
                 <ul>
                   <li>Creating and using a system to distribute web resources to others.</li>
                   <li>Contributing and finding content for the benefit of others.</li>
@@ -149,7 +149,7 @@ var ActivitiesPage = React.createClass({
                   <li>Identifying when it is safe to contribute content in a variety of situations on the web.</li>
                 </ul>
               </Expander>
-              <Expander head="collaborating">
+              <Expander head="collaborating" id="collaborating">
                 <ul>
                   <li>Choosing a Web tool to use for a particular contribution/ collaboration.</li>
                   <li>Co-creating Web resources.</li>
@@ -158,7 +158,7 @@ var ActivitiesPage = React.createClass({
                   <li>Developing and communicating a set of shared expectations and outcomes.</li>
                 </ul>
               </Expander>
-              <Expander head="participation">
+              <Expander head="participation" id="participation">
                 <ul>
                   <li>Engaging in web communities at varying levels of activity.</li>
                   <li>Respecting community norms when expressing opinions in web discussions.</li>
@@ -166,7 +166,7 @@ var ActivitiesPage = React.createClass({
                   <li>Participating in both synchronous and asynchronous discussions.</li>
                 </ul>
               </Expander>
-              <Expander head="privacy">
+              <Expander head="privacy" id="privacy">
                 <ul>
                   <li>Debating privacy as a value and right in a networked world.</li>
                   <li>Explaining ways in which unsolicited third parties can track users across the web.</li>
@@ -175,7 +175,7 @@ var ActivitiesPage = React.createClass({
                   <li>Managing and shaping online identities.</li>
                 </ul>
               </Expander>
-              <Expander head="open practices">
+              <Expander head="open practices" id="open-practices">
                 <ul>
                   <li>Distinguishing between open and closed licensing.</li>
                   <li>Making web resources available under an open license.</li>

--- a/pages/web-literacy.jsx
+++ b/pages/web-literacy.jsx
@@ -49,7 +49,7 @@ var ActivitiesPage = React.createClass({
         <section>
           <WebMaps>
             <WebMap head="Explore" subhead="Reading the Web">
-              <Expander head="navigation" id="navigation">
+              <Expander head="navigation" anchorId="navigation">
                 <ul>
                   <li>Accessing the web using the common features of a browser.</li>
                   <li>Using hyperlinks to access a range of resources on the web.</li>
@@ -58,7 +58,7 @@ var ActivitiesPage = React.createClass({
                   <li>Exploring browser add-ons and extensions to provide additional functionality.</li>
                 </ul>
               </Expander>
-              <Expander head="web mechanics" id="web-mechanics">
+              <Expander head="web mechanics" anchorId="web-mechanics">
                 <ul>
                   <li>Using and understanding the differences between URLs, IP addresses and search terms.</li>
                   <li>Identifying where data is in the network of devices that makes up the Internet.</li>
@@ -67,7 +67,7 @@ var ActivitiesPage = React.createClass({
                   <li>Creating or modifying an algorithm to serve content from around the web.</li>
                 </ul>
               </Expander>
-              <Expander head="search" id="search">
+              <Expander head="search" anchorId="search">
                 <ul>
                   <li>Developing questions to aid a search.</li>
                   <li>Using and revising keywords to make web searches more efficient.</li>
@@ -76,7 +76,7 @@ var ActivitiesPage = React.createClass({
                   <li>Discovering information and resources by asking people within social networks.</li>
                 </ul>
               </Expander>
-              <Expander head="credibility" id="credibility">
+              <Expander head="credibility" anchorId="credibility">
                 <ul>
                   <li>Comparing and contrasting information from a number of sources.</li>
                   <li>Making judgments based on technical and design characteristics.</li>
@@ -85,7 +85,7 @@ var ActivitiesPage = React.createClass({
                   <li>Evaluating how purpose and perspectives shape web resources.</li>
                 </ul>
               </Expander>
-              <Expander head="security" id="security">
+              <Expander head="security" anchorId="security">
                 <ul>
                   <li>Recommending how to avoid online scams and 'phishing’.</li>
                   <li>Managing and maintaining account security.</li>
@@ -95,7 +95,7 @@ var ActivitiesPage = React.createClass({
               </Expander>
             </WebMap>
             <WebMap head="Build" subhead="Writing the Web">
-              <Expander head="composing" id="composing">
+              <Expander head="composing" anchorId="composing">
                 <ul>
                   <li>Inserting hyperlinks into a web page.</li>
                   <li>Identifying and using HTML tags.</li>
@@ -104,7 +104,7 @@ var ActivitiesPage = React.createClass({
                   <li>Setting up and controlling a space to publish on the Web.</li>
                 </ul>
               </Expander>
-              <Expander head="remixing" id="remixing">
+              <Expander head="remixing" anchorId="remixing">
                 <ul>
                   <li>Identifying remixable content.</li>
                   <li>Combining multimedia resources to create something new on the web.</li>
@@ -112,7 +112,7 @@ var ActivitiesPage = React.createClass({
                   <li>Citing and referencing original content.</li>
                 </ul>
               </Expander>
-              <Expander head="designing" id="designing">
+              <Expander head="designing" anchorId="designing">
                 <ul>
                   <li>Using CSS properties to change the style and layout of a Web page.</li>
                   <li>Demonstrating the difference between inline, embedded and external CSS.</li>
@@ -120,7 +120,7 @@ var ActivitiesPage = React.createClass({
                   <li>Creating device-agnostic web resources.</li>
                 </ul>
               </Expander>
-              <Expander head="coding/scripting" id="coding-scripting">
+              <Expander head="coding/scripting" anchorId="coding-scripting">
                 <ul>
                   <li>Reading and explaining the structure of code.</li>
                   <li>Identifying and applying common coding patterns and concepts.</li>
@@ -129,7 +129,7 @@ var ActivitiesPage = React.createClass({
                   <li>Querying a web service using an API.</li>
                 </ul>
               </Expander>
-              <Expander head="accessibility" id="accessibility">
+              <Expander head="accessibility" anchorId="accessibility">
                 <ul>
                   <li>Using empathy and awareness to inform the design of web content that is accessible to all users.</li>
                   <li>Designing for different cultures which may have different interpretations of design elements.</li>
@@ -140,7 +140,7 @@ var ActivitiesPage = React.createClass({
               </Expander>
             </WebMap>
             <WebMap head="Connect" subhead="Participating on the Web">
-              <Expander head="sharing" id="sharing">
+              <Expander head="sharing" anchorId="sharing">
                 <ul>
                   <li>Creating and using a system to distribute web resources to others.</li>
                   <li>Contributing and finding content for the benefit of others.</li>
@@ -149,7 +149,7 @@ var ActivitiesPage = React.createClass({
                   <li>Identifying when it is safe to contribute content in a variety of situations on the web.</li>
                 </ul>
               </Expander>
-              <Expander head="collaborating" id="collaborating">
+              <Expander head="collaborating" anchorId="collaborating">
                 <ul>
                   <li>Choosing a Web tool to use for a particular contribution/ collaboration.</li>
                   <li>Co-creating Web resources.</li>
@@ -158,7 +158,7 @@ var ActivitiesPage = React.createClass({
                   <li>Developing and communicating a set of shared expectations and outcomes.</li>
                 </ul>
               </Expander>
-              <Expander head="participation" id="participation">
+              <Expander head="participation" anchorId="participation">
                 <ul>
                   <li>Engaging in web communities at varying levels of activity.</li>
                   <li>Respecting community norms when expressing opinions in web discussions.</li>
@@ -166,7 +166,7 @@ var ActivitiesPage = React.createClass({
                   <li>Participating in both synchronous and asynchronous discussions.</li>
                 </ul>
               </Expander>
-              <Expander head="privacy" id="privacy">
+              <Expander head="privacy" anchorId="privacy">
                 <ul>
                   <li>Debating privacy as a value and right in a networked world.</li>
                   <li>Explaining ways in which unsolicited third parties can track users across the web.</li>
@@ -175,7 +175,7 @@ var ActivitiesPage = React.createClass({
                   <li>Managing and shaping online identities.</li>
                 </ul>
               </Expander>
-              <Expander head="open practices" id="open-practices">
+              <Expander head="open practices" anchorId="open-practices">
                 <ul>
                   <li>Distinguishing between open and closed licensing.</li>
                   <li>Making web resources available under an open license.</li>

--- a/test/browser/anchor-manager.test.jsx
+++ b/test/browser/anchor-manager.test.jsx
@@ -1,0 +1,103 @@
+var _ = require('underscore');
+var React = require('react/addons');
+var should = require('should');
+var sinon = window.sinon;
+
+var AnchorManagerMixin = require('../../mixins/anchor-manager');
+
+var SampleAnchorClass = React.createClass({
+  mixins: [AnchorManagerMixin],
+  render: function() {
+    return <div></div>;
+  }
+});
+
+describe('AnchorManagerMixin', function() {
+  var manager, anchors;
+
+  var renderAnchor = function(props) {
+    var anchor = React.addons.TestUtils.renderIntoDocument(
+      <SampleAnchorClass anchorManager={manager} {...props}/>
+    );
+    anchors.push(anchor);
+    return anchor;
+  };
+
+  var unmountAnchor = function(anchor) {
+    React.unmountComponentAtNode(anchor.getDOMNode().parentNode);
+    anchors.splice(anchors.indexOf(anchor, 1));
+  };
+
+  beforeEach(function() {
+    manager = new AnchorManagerMixin.AnchorManager();
+    manager.initialize = sinon.spy();
+    manager.getHash = sinon.spy();
+    anchors = [];
+  });
+
+  afterEach(function() {
+    anchors.slice().forEach(unmountAnchor);
+    anchors.length.should.equal(0);
+  });
+
+  it('should not do anything if anchorId is not defined', function() {
+    renderAnchor();
+    Object.keys(manager.anchorMap).should.eql([]);
+    manager.initialized.should.be.false;
+  });
+
+  it('should register w/ anchor manager if anchorId is defined', function() {
+    renderAnchor({anchorId: 'foo'});
+    Object.keys(manager.anchorMap).should.eql(['foo']);
+  });
+
+  it('should use singleton anchor manger by default', function() {
+    var m1 = SampleAnchorClass.getDefaultProps().anchorManager;
+    var m2 = SampleAnchorClass.getDefaultProps().anchorManager;
+
+    m1.should.be.an.Object;
+    m1.should.equal(m2);
+  });
+
+  it('should lazily initialize anchor manager', function() {
+    manager.initialized.should.be.false;
+    renderAnchor({anchorId: 'bar'});
+    manager.initialized.should.be.true;
+    manager.initialize.callCount.should.equal(1);
+  });
+
+  it('should not initialize anchor manager multiple times', function() {
+    renderAnchor({anchorId: 'foo'});
+    renderAnchor({anchorId: 'bar'});
+    manager.initialize.callCount.should.equal(1);
+  });
+
+  it('should log warnings when anchor names collide', function() {
+    var foo1, foo2;
+
+    sinon.stub(console, 'warn');
+
+    foo1 = renderAnchor({anchorId: 'foo'});
+    console.warn.callCount.should.equal(0);
+
+    foo2 = renderAnchor({anchorId: 'foo'});
+    console.warn.callCount.should.equal(1);
+    console.warn.getCall(0).args.should.eql([
+      'Anchor for #foo already registered.'
+    ]);
+
+    unmountAnchor(foo1);
+    console.warn.callCount.should.equal(2);
+    console.warn.getCall(1).args.should.eql([
+      'Anchor mismatch for #foo.'
+    ]);
+
+    unmountAnchor(foo2);
+    console.warn.callCount.should.equal(3);
+    console.warn.getCall(2).args.should.eql([
+      'Anchor for #foo does not exist.'
+    ]);
+
+    console.warn.restore();
+  });
+});

--- a/test/browser/anchor-manager.test.jsx
+++ b/test/browser/anchor-manager.test.jsx
@@ -239,4 +239,37 @@ describe('AnchorManagerMixin', function() {
     a.cancelAttractAttentionToAnchor.callCount.should.equal(1);
     a.cancelAttractAttentionToAnchor.restore();
   });
+
+  it('does not attract attention to anchor when mounted', function() {
+    var a = renderAnchor({anchorId: 'foo'});
+    a.state.attractAttentionToAnchor.should.be.false;
+  });
+
+  it('attracts attention to anchor when navigated to', function() {
+    var a = renderAnchor({anchorId: 'foo'});
+    manager.simulateHashChange('foo');
+    a.state.attractAttentionToAnchor.should.be.true;
+  });
+
+  it('stops attracting attention to anchor after some time', function() {
+    var a = renderAnchor({anchorId: 'foo'});
+    manager.simulateHashChange('foo');
+    clock.tick(AnchorManagerMixin.DEFAULT_ATTRACT_DURATION + 1);
+    a.state.attractAttentionToAnchor.should.be.false;
+  });
+
+  it('waits ATTRACT_ATTENTION_TO_ANCHOR_DURATION if defined', function() {
+    var a = renderAnchor({anchorId: 'foo'});
+    a.ATTRACT_ATTENTION_TO_ANCHOR_DURATION = 10;
+    a.attractAttentionToAnchor();
+    clock.tick(11);
+    a.state.attractAttentionToAnchor.should.be.false;
+  });
+
+  it('calls handleAttractAttentionToAnchor() if defined', function() {
+    var a = renderAnchor({anchorId: 'foo'});
+    a.handleAttractAttentionToAnchor = sinon.spy();
+    a.attractAttentionToAnchor();
+    a.handleAttractAttentionToAnchor.callCount.should.equal(1);
+  });
 });

--- a/test/browser/anchor-manager.test.jsx
+++ b/test/browser/anchor-manager.test.jsx
@@ -5,15 +5,167 @@ var sinon = window.sinon;
 
 var AnchorManagerMixin = require('../../mixins/anchor-manager');
 
-var SampleAnchorClass = React.createClass({
-  mixins: [AnchorManagerMixin],
-  render: function() {
-    return <div></div>;
-  }
+var createAnchorManager = function() {
+  var manager = new AnchorManagerMixin.AnchorManager();
+
+  // Stub out the methods that access the window object.
+  manager.initialize = sinon.stub();
+  manager.getHash = sinon.stub();
+
+  manager.simulateHashChange = function(hash) {
+    manager.getHash.returns(hash);
+    manager.handleHashChange();
+  };
+  return manager;
+};
+
+describe('AnchorManager', function() {
+  var manager;
+
+  var fakeAnchor = function(anchorId) {
+    return {
+      props: {anchorId: anchorId},
+      handleNavigateFromAnchor: sinon.spy(),
+      handleNavigateToAnchor: sinon.spy()
+    };
+  };
+
+  beforeEach(function() {
+    manager = createAnchorManager();
+  });
+
+  it('should initialize itself only upon registration', function() {
+    manager.initialized.should.be.false;
+    manager.register(fakeAnchor('foo'));
+    manager.initialized.should.be.true;
+    manager.initialize.callCount.should.equal(1);
+  });
+
+  it('should not initialize itself multiple times', function() {
+    manager.register(fakeAnchor('foo'));
+    manager.register(fakeAnchor('bar'));
+    manager.initialize.callCount.should.equal(1);
+  });
+
+  it('should add to anchorMap on registration', function() {
+    var anchor = manager.register(fakeAnchor('foo'));
+    manager.anchorMap.should.eql({'foo': anchor});
+  });
+
+  it('should remove from anchorMap on unregistration', function() {
+    var anchor = manager.register(fakeAnchor('foo'));
+    manager.unregister(anchor);
+    manager.anchorMap.should.eql({});
+  });
+
+  it('should reset currentAnchor on unregister if needed', function() {
+    var anchor = manager.register(fakeAnchor('foo'));
+    manager.currentAnchor = anchor;
+    manager.unregister(anchor);
+    should(manager.currentAnchor).be.null;
+  });
+
+  it('should not reset currentAnchor on unregister if unneeded', function() {
+    var anchor = manager.register(fakeAnchor('foo'));
+    var otherAnchor = manager.register(fakeAnchor('bar'));
+    manager.currentAnchor = otherAnchor;
+    manager.unregister(anchor);
+    manager.currentAnchor.should.equal(otherAnchor);
+  });
+
+  it('should warn when registering duplicate anchor name', function() {
+    sinon.stub(console, 'warn');
+
+    manager.register(fakeAnchor('foo'));
+    console.warn.callCount.should.equal(0);
+
+    manager.register(fakeAnchor('foo'));
+    console.warn.callCount.should.equal(1);
+    console.warn.getCall(0).args.should.eql([
+      'Anchor for #foo already registered.'
+    ]);
+    console.warn.restore();
+  });
+
+  it('should warn when unregistering nonexistent anchor name', function() {
+    sinon.stub(console, 'warn');
+
+    manager.unregister(fakeAnchor('foo'));
+    console.warn.callCount.should.equal(1);
+    console.warn.getCall(0).args.should.eql([
+      'Anchor for #foo does not exist.'
+    ]);
+    console.warn.restore();
+  });
+
+  it('should warn when unregistering invalid anchor component', function() {
+    sinon.stub(console, 'warn');
+
+    manager.register(fakeAnchor('foo'));
+    manager.unregister(fakeAnchor('foo'));
+    console.warn.callCount.should.equal(1);
+    console.warn.getCall(0).args.should.eql([
+      'Anchor mismatch for #foo.'
+    ]);
+    console.warn.restore();
+  });
+
+  it('should no-op if hash changes between unmatched anchors', function() {
+    var anchor = manager.register(fakeAnchor('foo'));
+    manager.simulateHashChange('blah');
+    anchor.handleNavigateFromAnchor.callCount.should.equal(0);
+    anchor.handleNavigateToAnchor.callCount.should.equal(0);
+    should(manager.currentAnchor).be.null;
+  });
+
+  it('should no-op if hash matches current anchor', function() {
+    var anchor = manager.register(fakeAnchor('foo'));
+    manager.currentAnchor = anchor;
+    manager.simulateHashChange('foo');
+    anchor.handleNavigateFromAnchor.callCount.should.equal(0);
+    anchor.handleNavigateToAnchor.callCount.should.equal(0);
+    manager.currentAnchor.should.equal(anchor);
+  });
+
+  it('should navigate from unmatched anchor to matched anchor', function() {
+    var anchor = manager.register(fakeAnchor('foo'));
+    manager.simulateHashChange('foo');
+    anchor.handleNavigateFromAnchor.callCount.should.equal(0);
+    anchor.handleNavigateToAnchor.callCount.should.equal(1);
+    manager.currentAnchor.should.equal(anchor);
+  });
+
+  it('should navigate from old anchor to unmatched anchor', function() {
+    var fooAnchor = manager.register(fakeAnchor('foo'));
+    manager.currentAnchor = fooAnchor;
+    manager.simulateHashChange('blah');
+    fooAnchor.handleNavigateFromAnchor.callCount.should.equal(1);
+    fooAnchor.handleNavigateToAnchor.callCount.should.equal(0);
+    should(manager.currentAnchor).be.null;
+  });
+
+  it('should navigate from old anchor to matched anchor', function() {
+    var fooAnchor = manager.register(fakeAnchor('foo'));
+    var barAnchor = manager.register(fakeAnchor('bar'));
+    manager.currentAnchor = fooAnchor;
+    manager.simulateHashChange('bar');
+    fooAnchor.handleNavigateFromAnchor.callCount.should.equal(1);
+    fooAnchor.handleNavigateToAnchor.callCount.should.equal(0);
+    barAnchor.handleNavigateFromAnchor.callCount.should.equal(0);
+    barAnchor.handleNavigateToAnchor.callCount.should.equal(1);
+    manager.currentAnchor.should.equal(barAnchor);
+  });
 });
 
 describe('AnchorManagerMixin', function() {
   var manager, anchors;
+
+  var SampleAnchorClass = React.createClass({
+    mixins: [AnchorManagerMixin],
+    render: function() {
+      return <div></div>;
+    }
+  });
 
   var renderAnchor = function(props) {
     var anchor = React.addons.TestUtils.renderIntoDocument(
@@ -29,9 +181,7 @@ describe('AnchorManagerMixin', function() {
   };
 
   beforeEach(function() {
-    manager = new AnchorManagerMixin.AnchorManager();
-    manager.initialize = sinon.spy();
-    manager.getHash = sinon.spy();
+    manager = createAnchorManager();
     anchors = [];
   });
 
@@ -51,53 +201,17 @@ describe('AnchorManagerMixin', function() {
     Object.keys(manager.anchorMap).should.eql(['foo']);
   });
 
+  it('should unregister w/ anchor manager on unmount', function() {
+    var a = renderAnchor({anchorId: 'foo'});
+    unmountAnchor(a);
+    Object.keys(manager.anchorMap).should.eql([]);
+  });
+
   it('should use singleton anchor manger by default', function() {
     var m1 = SampleAnchorClass.getDefaultProps().anchorManager;
     var m2 = SampleAnchorClass.getDefaultProps().anchorManager;
 
     m1.should.be.an.Object;
     m1.should.equal(m2);
-  });
-
-  it('should lazily initialize anchor manager', function() {
-    manager.initialized.should.be.false;
-    renderAnchor({anchorId: 'bar'});
-    manager.initialized.should.be.true;
-    manager.initialize.callCount.should.equal(1);
-  });
-
-  it('should not initialize anchor manager multiple times', function() {
-    renderAnchor({anchorId: 'foo'});
-    renderAnchor({anchorId: 'bar'});
-    manager.initialize.callCount.should.equal(1);
-  });
-
-  it('should log warnings when anchor names collide', function() {
-    var foo1, foo2;
-
-    sinon.stub(console, 'warn');
-
-    foo1 = renderAnchor({anchorId: 'foo'});
-    console.warn.callCount.should.equal(0);
-
-    foo2 = renderAnchor({anchorId: 'foo'});
-    console.warn.callCount.should.equal(1);
-    console.warn.getCall(0).args.should.eql([
-      'Anchor for #foo already registered.'
-    ]);
-
-    unmountAnchor(foo1);
-    console.warn.callCount.should.equal(2);
-    console.warn.getCall(1).args.should.eql([
-      'Anchor mismatch for #foo.'
-    ]);
-
-    unmountAnchor(foo2);
-    console.warn.callCount.should.equal(3);
-    console.warn.getCall(2).args.should.eql([
-      'Anchor for #foo does not exist.'
-    ]);
-
-    console.warn.restore();
   });
 });

--- a/test/browser/anchor-manager.test.jsx
+++ b/test/browser/anchor-manager.test.jsx
@@ -163,7 +163,7 @@ describe('AnchorManagerMixin', function() {
 
   var unmountAnchor = function(anchor) {
     React.unmountComponentAtNode(anchor.getDOMNode().parentNode);
-    anchors.splice(anchors.indexOf(anchor, 1));
+    anchors.splice(anchors.indexOf(anchor), 1);
   };
 
   beforeEach(function() {
@@ -248,6 +248,7 @@ describe('AnchorManagerMixin', function() {
     var a = renderAnchor({anchorId: 'foo'});
     a.ATTRACT_ATTENTION_TO_ANCHOR_DURATION = 10;
     a.attractAttentionToAnchor();
+    a.state.attractAttentionToAnchor.should.be.true;
     clock.tick(11);
     a.state.attractAttentionToAnchor.should.be.false;
   });

--- a/test/browser/anchor-manager.test.jsx
+++ b/test/browser/anchor-manager.test.jsx
@@ -1,23 +1,9 @@
-var _ = require('underscore');
 var React = require('react/addons');
 var should = require('should');
 var sinon = window.sinon;
 
 var AnchorManagerMixin = require('../../mixins/anchor-manager');
-
-var createAnchorManager = function() {
-  var manager = new AnchorManagerMixin.AnchorManager();
-
-  // Stub out the methods that access the window object.
-  manager.initialize = sinon.stub();
-  manager.getHash = sinon.stub();
-
-  manager.simulateHashChange = function(hash) {
-    manager.getHash.returns(hash);
-    manager.handleHashChange();
-  };
-  return manager;
-};
+var StubAnchorManager = require('./stub-anchor-manager');
 
 describe('AnchorManager', function() {
   var manager;
@@ -31,7 +17,7 @@ describe('AnchorManager', function() {
   };
 
   beforeEach(function() {
-    manager = createAnchorManager();
+    manager = StubAnchorManager();
   });
 
   it('should initialize itself only upon registration', function() {
@@ -182,7 +168,7 @@ describe('AnchorManagerMixin', function() {
 
   beforeEach(function() {
     clock = sinon.useFakeTimers();
-    manager = createAnchorManager();
+    manager = StubAnchorManager();
     anchors = [];
   });
 

--- a/test/browser/expander.test.jsx
+++ b/test/browser/expander.test.jsx
@@ -1,15 +1,29 @@
+var _ = require('underscore');
 var should = require('should');
 var React =require('react/addons');
 var TestUtils = React.addons.TestUtils;
+var sinon = window.sinon;
 
 var stubContext = require('./stub-context.jsx');
+var StubAnchorManager = require('./stub-anchor-manager');
 var Expander = require('../../components/expander.jsx');
 
 describe("Expander", function() {
-  var expander, itemContainer, itemHeader;
+  var expander, itemContainer, itemHeader, anchorManager, clock;
 
-  beforeEach(function() {
-    expander = stubContext.render(Expander, {});
+  var isAttractingAttention = function() {
+    return TestUtils.scryRenderedDOMComponentsWithClass(
+      expander,
+      'attract-attention'
+    ).length === 1;
+  };
+
+  var createExpander = function(props) {
+    clock = sinon.useFakeTimers();
+    anchorManager = StubAnchorManager();
+    expander = stubContext.render(Expander, _.extend({
+      anchorManager: anchorManager
+    }, props));
     itemContainer = TestUtils.findRenderedDOMComponentWithClass(
       expander,
       'expand-div'
@@ -18,25 +32,74 @@ describe("Expander", function() {
       expander,
       'expander-header'
     );
+    return expander;
+  };
+
+  beforeEach(function() {
+    expander = itemContainer = itemHeader = null;
   });
 
   afterEach(function() {
-    stubContext.unmount(expander);
+    if (expander) {
+      stubContext.unmount(expander);
+    }
+    clock.restore();
   });
 
   it('should hide collapsed content by default', function() {
+    createExpander();
     expander.state.expanded.should.be.false;
   });
 
   it('should hide collapsible content', function() {
+    createExpander();
     itemContainer.props.className.should.not.match(/expanded/);
   });
 
   it('should toggle collapsible content on mouse down', function() {
+    createExpander();
     TestUtils.Simulate.mouseDown(itemHeader);
     itemContainer.props.className.should.match(/expanded/);
     TestUtils.Simulate.mouseDown(itemHeader);
     itemContainer.props.className.should.not.match(/expanded/);
   });
 
+  it('should not show permalink if anchorId does not exist', function() {
+    createExpander();
+    TestUtils.scryRenderedDOMComponentsWithClass(
+      expander,
+      'expander-permalink'
+    ).length.should.equal(0);
+  });
+
+  it('should show permalink if anchorId exists', function() {
+    createExpander({anchorId: 'sup'});
+    TestUtils.findRenderedDOMComponentWithClass(
+      expander,
+      'expander-permalink'
+    ).props.href.should.equal('#sup');
+  });
+
+  it('should not attract attention to content by default', function() {
+    createExpander();
+    isAttractingAttention().should.be.false;
+  });
+
+  it('should attract user to content when focused via kbd', function() {
+    createExpander();
+    TestUtils.Simulate.keyUp(itemHeader, {which: 9});
+    expander.state.expanded.should.be.true;
+    isAttractingAttention().should.be.true;
+    clock.tick(99999);
+    isAttractingAttention().should.be.false;
+  });
+
+  it('should attract user to content when navigated to', function() {
+    createExpander({anchorId: 'sup'});
+    anchorManager.simulateHashChange('sup');
+    expander.state.expanded.should.be.true;
+    isAttractingAttention().should.be.true;
+    clock.tick(99999);
+    isAttractingAttention().should.be.false;
+  });
 });

--- a/test/browser/expander.test.jsx
+++ b/test/browser/expander.test.jsx
@@ -22,6 +22,7 @@ describe("Expander", function() {
     clock = sinon.useFakeTimers();
     anchorManager = StubAnchorManager();
     expander = stubContext.render(Expander, _.extend({
+      head: 'heading text',
       anchorManager: anchorManager
     }, props));
     itemContainer = TestUtils.findRenderedDOMComponentWithClass(

--- a/test/browser/stub-anchor-manager.js
+++ b/test/browser/stub-anchor-manager.js
@@ -1,0 +1,19 @@
+var sinon = window.sinon;
+
+var AnchorManagerMixin = require('../../mixins/anchor-manager');
+
+var StubAnchorManager = function() {
+  var manager = new AnchorManagerMixin.AnchorManager();
+
+  // Stub out the methods that access the window object.
+  manager.initialize = sinon.stub();
+  manager.getHash = sinon.stub();
+
+  manager.simulateHashChange = function(hash) {
+    manager.getHash.returns(hash);
+    manager.handleHashChange();
+  };
+  return manager;
+};
+
+module.exports = StubAnchorManager;


### PR DESCRIPTION
This is a potential fix for #975. It's a bit weird because our Expander already actually behaves somewhat inconsistently, and making it accessible is not particularly straightforward.

Right now this adds a [section sign (§)](http://en.wikipedia.org/wiki/Section_sign) at the top-right of each expander section. Clicking on it will set your browser's current URL to a permalink for the section. Here's an example permalink to the Accessibility section of the Web Literacy Map, hosted on my personal deployment branch thingy:

http://mozteach.toolness.org/teach-like-mozilla/web-literacy/#accessibility

Visiting that *should* automatically expand the Accessibility section and focus keyboard navigation on it.

(You can also see what that link looks like [with JS disabled](http://mozteach.toolness.org/teach-like-mozilla/web-literacy/?safemode=on#accessibility).)

Right now this PR throws out a lot of the focus/blur stuff in the existing code because (A) it was buggy/not behaving consistently and (B) trying to make it un-buggy resulted in lots of weird annoying edge cases, such as always collapsing the current section when switching to a different application.
