### PR TITLE
Fixes #966 - update email address

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -27,4 +27,5 @@ exports.IN_TEST_SUITE = (typeof describe == 'function');
 exports.DEV_SERVER_PORT = DEV_SERVER_PORT;
 exports.TWITTER_HANDLE = '@MozTeach';
 exports.TWITTER_LINK = 'https://twitter.com/MozTeach';
+exports.TEACH_THE_WEB_EMAIL = 'teachtheweb@mozillafoundation.org';
 exports.ORIGIN = ORIGIN;

--- a/pages/about.jsx
+++ b/pages/about.jsx
@@ -92,7 +92,7 @@ var AboutPage = React.createClass({
               subhead="Start a conversation on Twitter"
             />
             <IconLink
-              href="mailto:teachtheweb@mozillafoundation.org"
+              href={"mailto:"+config.TEACH_THE_WEB_EMAIL}
               imgSrc="/img/pages/about/svg/icon-get-help-blue.svg"
               head="Get Help"
               subhead="Email us anytime"

--- a/pages/clubs-toolkit.jsx
+++ b/pages/clubs-toolkit.jsx
@@ -84,7 +84,7 @@ var ClubsToolkit = React.createClass({
                   Our community loves to tweet! Share ideas and send pictures to <a href={config.TWITTER_LINK}>{config.TWITTER_HANDLE}</a> and use the tag <a href="https://twitter.com/search?q=%23teachtheweb">#TeachTheWeb</a>
                 </ToolkitListItem>
                 <ToolkitListItem header="Email.">
-                  We’re always here to answer your questions and connect you to other clubs. Send an email to <a href="mailto:help@webmaker.org">help@webmaker.org</a>
+                  We’re always here to answer your questions and connect you to other clubs. Send an email to <a href={"mailto:"+config.TEACH_THE_WEB_EMAIL}>{config.TEACH_THE_WEB_EMAIL}</a>
                 </ToolkitListItem>
               </ToolkitList>
             </Toolkit>

--- a/pages/event-resources.jsx
+++ b/pages/event-resources.jsx
@@ -3,6 +3,8 @@ var ImageTag = require('../components/imagetag.jsx');
 var Router = require('react-router');
 var Link = Router.Link;
 
+var config = require('../lib/config');
+
 var PageLinker = React.createClass({
   render: function() {
     return (
@@ -400,7 +402,7 @@ var EventsResources = React.createClass({
             alt="request support image"/>
             <h3 className="event-support-header">Request Support</h3>
             <p>
-              Still can't find an answer to your question? Our team is here to help you with all things Maker Party. <a href="mailto:teachtheweb@mozillafoundation.org">Contact us</a> and we will get back to you as soon as possible.
+              Still can't find an answer to your question? Our team is here to help you with all things Maker Party. <a href={"mailto:"+config.TEACH_THE_WEB_EMAIL}>Contact us</a> and we will get back to you as soon as possible.
             </p>
           </div>
         </div>

--- a/pages/home.jsx
+++ b/pages/home.jsx
@@ -193,7 +193,7 @@ var HomePage = React.createClass({
               subhead="Start a conversation on Twitter"
             />
             <IconLink
-              href="mailto:teachtheweb@mozillafoundation.org"
+              href={"mailto:"+config.TEACH_THE_WEB_EMAIL}
               imgSrc="/img/pages/about/svg/icon-get-help-blue.svg"
               head="Get Help"
               subhead="Email us anytime"


### PR DESCRIPTION
This fixes #966 .

I also stored `teachtheweb@mozillafoundation.org` as a `const`, just like what we did for the [Twitter link/handle](https://github.com/mozilla/teach.webmaker.org/pull/944).