### PR TITLE
Make the expander and tabulator print-friendly

### DIFF
--- a/less/components/expander.less
+++ b/less/components/expander.less
@@ -1,4 +1,4 @@
-html.no-js {
+.expander-hide-nothing() {
   .expander-container {
     .expand-div {
       outline: 0;
@@ -12,17 +12,12 @@ html.no-js {
   }
 }
 
+html.no-js {
+  .expander-hide-nothing();
+}
+
 @media print {
-  .expander-container {
-    .expand-div {
-      .ion {
-        display: none;
-      }
-      .expander-items-container {
-        max-height: none;
-      }
-    }
-  }
+  .expander-hide-nothing();
 }
 
 .expander-container {

--- a/less/components/expander.less
+++ b/less/components/expander.less
@@ -12,6 +12,19 @@ html.no-js {
   }
 }
 
+@media print {
+  .expander-container {
+    .expand-div {
+      .ion {
+        display: none;
+      }
+      .expander-items-container {
+        max-height: none;
+      }
+    }
+  }
+}
+
 .expander-container {
   .expander-header {
     cursor: pointer;

--- a/less/pages/event-resources.less
+++ b/less/pages/event-resources.less
@@ -1,4 +1,4 @@
-html.no-js {
+.tabulator-hide-nothing() {
   .tabulator {
     .tabulator-head {
       display: none;
@@ -16,6 +16,20 @@ html.no-js {
     .tabulator-content-container {
       display: inline-block;
     }
+  }
+}
+
+html.no-js {
+  .tabulator-hide-nothing();
+}
+
+@media print {
+  .tabulator-hide-nothing();
+  .tabulator-head-no-js {
+    display: block !important;
+  }
+  .tabulator-content-container {
+    display: inline-block !important;
   }
 }
 


### PR DESCRIPTION
This helps with the very basics of #638 by at least making expander and tabulator content completely visible (rather than collapsed) when printed. This is primarily done just by reusing our CSS for javascript-disabled browsers.

The easiest way to manually test this is with Chrome, which has a handy print preview. This is what the Web Literacy map looks like without this PR:

![2015-06-04_12-06-15](https://cloud.githubusercontent.com/assets/124687/7988598/3ed26342-0ab2-11e5-8435-62455c44dac7.jpg)

As you can see, this is pretty useless because the actual content is collapsed.

With this PR, it looks like this:

![2015-06-04_12-06-53](https://cloud.githubusercontent.com/assets/124687/7988622/54dbfbb2-0ab2-11e5-8f6a-c44c1fbac9ff.jpg)
