### PR TITLE
Add zoom-to-location link in club list view

### DIFF
--- a/less/pages/clubs.less
+++ b/less/pages/clubs.less
@@ -5,3 +5,12 @@
     background-image: url(/img/pages/clubs/hero-clubs@2x.png);
   });
 }
+
+.club-location {
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.club-location:hover {
+  color: @link-color;
+}

--- a/pages/clubs.jsx
+++ b/pages/clubs.jsx
@@ -24,7 +24,11 @@ var ClubListItem = React.createClass({
     club: React.PropTypes.object.isRequired,
     username: React.PropTypes.string,
     onDelete: React.PropTypes.func,
-    onEdit: React.PropTypes.func
+    onEdit: React.PropTypes.func,
+    onZoomToLocation: React.PropTypes.func.isRequired
+  },
+  handleLocationClick: function() {
+    this.props.onZoomToLocation(this.props.club);
   },
   render: function() {
     var club = this.props.club;
@@ -49,7 +53,7 @@ var ClubListItem = React.createClass({
     return (
       <li>
         <h4>{clubName} <Map.ClubStatusLabel showApproved={isOwned} status={club.status}/></h4>
-        <p><em>{club.location.split(',')[0]}</em></p>
+        <p><span className="club-location" onClick={this.handleLocationClick}><span className="glyphicon glyphicon-map-marker"/> {club.location.split(',')[0]}</span></p>
         <p>{club.description}</p>
         <p><small>Led by <a href={"https://webmaker.org/en-US/search?type=user&q=" + club.owner}>{club.owner}</a></small></p>
         {ownerControls}
@@ -65,7 +69,8 @@ var ClubList = React.createClass({
     clubs: React.PropTypes.array.isRequired,
     username: React.PropTypes.string,
     onDelete: React.PropTypes.func,
-    onEdit: React.PropTypes.func
+    onEdit: React.PropTypes.func,
+    onZoomToLocation: React.PropTypes.func.isRequired
   },
   statics: {
     Item: ClubListItem
@@ -79,7 +84,8 @@ var ClubList = React.createClass({
             return  <ClubListItem key={i} club={club}
                                   username={this.props.username}
                                   onEdit={this.props.onEdit}
-                                  onDelete={this.props.onDelete} />;
+                                  onDelete={this.props.onDelete}
+                                  onZoomToLocation={this.props.onZoomToLocation} />;
           }, this)}
         </ul>
       </div>
@@ -507,7 +513,8 @@ var ClubLists = React.createClass({
     clubs: React.PropTypes.array.isRequired,
     username: React.PropTypes.string,
     onDelete: React.PropTypes.func.isRequired,
-    onEdit: React.PropTypes.func.isRequired
+    onEdit: React.PropTypes.func.isRequired,
+    onZoomToLocation: React.PropTypes.func.isRequired
   },
   componentWillMount: function() {
     this.componentWillReceiveProps(this.props);
@@ -545,7 +552,8 @@ var ClubLists = React.createClass({
              clubs={this.state.userClubs}
              username={this.props.username}
              onDelete={this.props.onDelete}
-             onEdit={this.props.onEdit}/>
+             onEdit={this.props.onEdit}
+             onZoomToLocation={this.props.onZoomToLocation}/>
              {this.state.userHasUnapprovedClubs ? (
                <div className="alert alert-warning">
                  <strong>Note:</strong> All clubs pending approval or denied are not visible to other users.
@@ -554,7 +562,9 @@ var ClubLists = React.createClass({
           </div>
         ) : null}
         <h3>Club List</h3>
-        <ClubList clubs={this.state.otherClubs}/>
+        <ClubList
+         clubs={this.state.otherClubs}
+         onZoomToLocation={this.props.onZoomToLocation}/>
       </div>
     );
   }
@@ -588,10 +598,10 @@ var ClubsPage = React.createClass({
   },
   showAddYourClubModal: function() {
     this.showModal(ModalAddOrChangeYourClub, {
-      onSuccess: this.handleAddClubSuccess
+      onSuccess: this.handleZoomToClub
     });
   },
-  handleAddClubSuccess: function(club) {
+  handleZoomToClub: function(club) {
     this.refs.map.getDOMNode().scrollIntoView();
     this.refs.map.focusOnClub(club);
   },
@@ -607,7 +617,7 @@ var ClubsPage = React.createClass({
     });
     this.showModal(ModalAddOrChangeYourClub, {
       club: club,
-      onSuccess: this.handleAddClubSuccess
+      onSuccess: this.handleZoomToClub
     });
   },
   render: function() {
@@ -637,7 +647,8 @@ var ClubsPage = React.createClass({
             <ClubLists clubs={clubs}
              username={username}
              onDelete={this.handleClubDelete}
-             onEdit={this.handleClubEdit}/>
+             onEdit={this.handleClubEdit}
+             onZoomToLocation={this.handleZoomToClub} />
           </section>
           <section>
             <Quote/>

--- a/test/browser/clubs-page.test.jsx
+++ b/test/browser/clubs-page.test.jsx
@@ -104,49 +104,46 @@ describe("ClubsPage.ClubLists", function() {
     status: 'pending',
     name: 'bar club'
   }];
+  var renderLists = function(props) {
+    props = _.extend({
+      clubs: clubs,
+      onDelete: noop,
+      onEdit: noop,
+      onZoomToLocation: noop
+    }, props);
+    return TestUtils.renderIntoDocument(<ClubLists {...props}/>);
+  };
 
   it("doesn't show 'My Clubs' when logged out", function() {
-    var lists = TestUtils.renderIntoDocument(
-      <ClubLists clubs={clubs} onDelete={noop} onEdit={noop}/>
-    );
+    var lists = renderLists();
     lists.getDOMNode().textContent.should.not.match(/My Clubs/);
   });
 
   it("shows 'My Clubs' when logged-in user has clubs", function() {
-    var lists = TestUtils.renderIntoDocument(
-      <ClubLists clubs={clubs} onDelete={noop} onEdit={noop} username="foo"/>
-    );
+    var lists = renderLists({username: 'foo'});
     lists.getDOMNode().textContent.should.match(/My Clubs/);
   });
 
   it("properly separates user's clubs from other clubs", function() {
-    var lists = TestUtils.renderIntoDocument(
-      <ClubLists clubs={clubs} onDelete={noop} onEdit={noop} username="foo"/>
-    );
+    var lists = renderLists({username: 'foo'})
     lists.state.userClubs.should.eql([clubs[0]]);
     lists.state.otherClubs.should.eql([clubs[1]]);
   });
 
   it("doesn't show note about unapproved clubs if there aren't any", function() {
-    var lists = TestUtils.renderIntoDocument(
-      <ClubLists clubs={clubs} onDelete={noop} onEdit={noop} username="foo"/>
-    );
+    var lists = renderLists({username: 'foo'});
     lists.getDOMNode().textContent.should.not.match(/Note:/);
     lists.state.userHasUnapprovedClubs.should.be.false;
   });
 
   it("shows note about unapproved clubs if there are any", function() {
-    var lists = TestUtils.renderIntoDocument(
-      <ClubLists clubs={clubs} onDelete={noop} onEdit={noop} username="bar"/>
-    );
+    var lists = renderLists({username: 'bar'});
     lists.getDOMNode().textContent.should.match(/Note:/);
     lists.state.userHasUnapprovedClubs.should.be.true;
   });
 
   it("updates its state when its props change", function() {
-    var lists = TestUtils.renderIntoDocument(
-      <ClubLists clubs={[]} onDelete={noop} onEdit={noop}/>
-    );
+    var lists = renderLists({clubs: []});
     lists.state.userHasUnapprovedClubs.should.be.false;
     lists.componentWillReceiveProps({ clubs: clubs, username: 'bar' });
     lists.state.userHasUnapprovedClubs.should.be.true;
@@ -165,56 +162,71 @@ describe("ClubsPage.ClubList", function() {
     status: 'approved',
     name: 'foo club'
   }];
+  var renderList = function(props) {
+    props = _.extend({
+      clubs: clubs,
+      onDelete: noop,
+      onEdit: noop,
+      onZoomToLocation: noop
+    }, props);
+    return TestUtils.renderIntoDocument(<ClubList {...props}/>);
+  };
 
   it("shows 1 club, passes expected props to it", function() {
-    var list = TestUtils.renderIntoDocument(
-      <ClubList clubs={clubs} onDelete={noop} onEdit={noop} username="meh" />
-    );
+    var list = renderList({username: 'meh'});
     var items = TestUtils.scryRenderedComponentsWithType(list, Item);
     items.length.should.equal(1);
     items[0].props.onEdit.should.equal(noop);
     items[0].props.onDelete.should.equal(noop);
+    items[0].props.onZoomToLocation.should.equal(noop);
     items[0].props.username.should.eql("meh");
     items[0].props.club.should.eql(clubs[0]);
   });
 
   describe("Item", function() {
+    var renderItem = function(props) {
+      props = _.extend({
+        club: clubs[0],
+        onDelete: noop,
+        onEdit: noop,
+        onZoomToLocation: noop
+      }, props);
+      return TestUtils.renderIntoDocument(<Item {...props}/>);
+    };
+
     it("hides edit controls when unowned", function() {
-      var item = TestUtils.renderIntoDocument(
-        <Item club={clubs[0]} onDelete={noop} onEdit={noop} username="a" />
-      );
+      var item = renderItem({username: 'a'});
       var btns = TestUtils.scryRenderedDOMComponentsWithTag(item, 'button');
       btns.length.should.equal(0);
     });
 
     it("shows pending info when status is pending", function() {
-      var item = TestUtils.renderIntoDocument(
-        <Item club={_.extend({}, clubs[0], {
-          status: 'pending'
-        })} onDelete={noop} onEdit={noop} />
-      );
+      var item = renderItem({
+        club: _.extend({}, clubs[0], { status: 'pending' })
+      });
       item.getDOMNode().textContent.should.match(/pending/);
     });
 
     it("shows denied info when status is denied", function() {
-      var item = TestUtils.renderIntoDocument(
-        <Item club={_.extend({}, clubs[0], {
-          status: 'denied'
-        })} onDelete={noop} onEdit={noop} />
-      );
+      var item = renderItem({
+        club: _.extend({}, clubs[0], { status: 'denied' })
+      });
       item.getDOMNode().textContent.should.match(/denied/);
     });
 
     describe("buttons", function() {
-      var item, onEdit, onDelete, editBtn, deleteBtn;
+      var item, onEdit, onDelete, onZoomToLocation, editBtn, deleteBtn;
 
       beforeEach(function() {
         onEdit = sinon.spy();
         onDelete = sinon.spy();
-        item = TestUtils.renderIntoDocument(
-          <Item club={clubs[0]} onDelete={onDelete}
-                onEdit={onEdit} username="foo" />
-        );
+        onZoomToLocation = sinon.spy();
+        item = renderItem({
+          username: 'foo',
+          onDelete: onDelete,
+          onEdit: onEdit,
+          onZoomToLocation: onZoomToLocation
+        });
         var btns = TestUtils.scryRenderedDOMComponentsWithTag(item, 'button');
         btns.length.should.equal(2);
 
@@ -235,6 +247,14 @@ describe("ClubsPage.ClubList", function() {
         onDelete.callCount.should.eql(1);
         onDelete.getCall(0).args[0].should.eql('http://api/clubs/1/');
         onDelete.getCall(0).args[1].should.eql('foo club');
+      });
+
+      it("should call onZoomToLocation", function() {
+        var loc = TestUtils.findRenderedDOMComponentWithClass(item, 'club-location');
+        onZoomToLocation.callCount.should.eql(0);
+        TestUtils.Simulate.click(loc);
+        onZoomToLocation.callCount.should.eql(1);
+        onZoomToLocation.getCall(0).args[0].should.equal(clubs[0]);
       });
     });
   });


### PR DESCRIPTION
This fixes #982 by adding a map marker icon in front of the city name in the club list view:

> ![2015-06-10_11-51-51](https://cloud.githubusercontent.com/assets/124687/8087137/28d126d2-0f67-11e5-8d1d-44ae16a8ae39.jpg)

When a user hovers over the icon or the city name, the line is highlighted in blue (the standard link color). When they click on it, the page immediately scrolls up to the map and focuses in on the club (the behavior is identical to what happens when the user clicks "take me to my club" at the end of the club submission process).

Note that this isn't an accessible solution, as the map marker only responds to click events and isn't focusable via the keyboard, but that's because the map itself isn't particularly accessible. I guess it might be a good idea to add support for sighted but keyboard-only users, since they might still want to be able to see where in the world the club is located, but I'm not sure if there's any good solution for non-sighted users. Other than perhaps adding some [`sr-only`](http://getbootstrap.com/css/#conveying-meaning-to-assistive-technologies) text after the city name that contains the region/country information too, so it's not ambiguous to screen reader users. I guess I recommend filing separate issues for these rather than addressing them in this PR.

Also, the code here is a lot bigger than one would expect, because we have to pass the new `onZoomToLocation` prop through a few levels of components. And because our test suite sorta violated DRY, I decided to refactor things a bit while making tests still pass without raising any React warnings.