### PR TITLE
Replace Ionicons used in Expander component

### DIFF
--- a/components/expander.jsx
+++ b/components/expander.jsx
@@ -57,7 +57,6 @@ var Expander = React.createClass({
            tabIndex="0" onKeyUp={this.handleKeyUp}
            onMouseDown={this.handleMouseDown}>
             {this.props.head}
-            <span className="ion"></span>
           </h4>
           <div className="expander-items-container" onFocus={this.expand}>
             {this.props.anchorId

--- a/less/components/expander.less
+++ b/less/components/expander.less
@@ -32,11 +32,10 @@ html.no-js {
     font-size: inherit;
     line-height: inherit;
     transition: background-color 0.5s ease;
-    .ion {
+    &:after {
       float: right;
-      &:before {
-        content: "\f123";
-      }
+      content: "\f078";
+      font-family: "FontAwesome";
     }
   }
   .expander-header:focus {
@@ -48,9 +47,9 @@ html.no-js {
   .expand-div {
     border-top: .2rem solid #fff;
     &.expanded {
-      .ion {
-        &:before {
-          content: "\f126";
+      .expander-header {
+        &:after {
+          content: "\f077";
         }
       }
       .expander-items-container {


### PR DESCRIPTION
This fixes #1041 

Replaced Ionicons with their FontAwesome twins

(screencap taken on the `/teach-like-mozilla/web-literacy/` page)
![screen shot 2015-06-17 at 1 08 53 pm](https://cloud.githubusercontent.com/assets/2896608/8217388/0e3d3c76-14f2-11e5-876e-3438350b2581.png)
