### PR TITLE
set og:image metadata and spider it.

### DIFF
--- a/lib/index-static.jsx
+++ b/lib/index-static.jsx
@@ -1,6 +1,7 @@
 var _  = require('underscore');
 var React = require('react');
 
+var config = require('./config');
 var routes = require('./routes.jsx');
 
 // This isn't actually called in node, it's stringified and plopped in
@@ -35,6 +36,7 @@ function generateWithPageHTML(url, options, pageHTML) {
         <meta charSet="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <meta property="og:description" content="We want more people to see themselves as citizens of the web. The Mozilla Learning Network offers programs and a global community dedicated to helping people learn the most important skills of our age: the ability to read, write and participate in the digital world."/>
+        <meta property="og:image" content={config.ORIGIN + "/img/pages/home/hero-unit.jpg"}/>
         {Object.keys(options.meta).map(function(name, i) {
           return <meta key={i} name={name} content={options.meta[name]}/>;
         })}

--- a/test/browser/spider.js
+++ b/test/browser/spider.js
@@ -3,12 +3,32 @@ var urlResolve = require('url').resolve;
 var chalk = require('chalk');
 var Crawler = require('simplecrawler');
 
+var config = require('../../lib/config');
 var server = require('./server').create();
+
+var URL_FINDERS = [
+  findSrcSetURLs,
+  findOpenGraphURLs
+];
 
 function findSrcSetURLs(resourceText, baseURL) {
   var urls = [];
 
   resourceText.replace(/\ssrcset\s?=\s?['"]([^"']+)/ig, function() {
+    arguments[1].split(',').forEach(function(resource) {
+      var url = resource.trim().split(' ')[0];
+
+      urls.push(urlResolve(baseURL || '', url));
+    });
+  });
+
+  return urls;
+}
+
+function findOpenGraphURLs(resourceText, baseURL) {
+  var urls = [];
+
+  resourceText.replace(/\sproperty="og:image"\s?content\s?=\s?['"]([^"']+)/ig, function() {
     arguments[1].split(',').forEach(function(resource) {
       var url = resource.trim().split(' ')[0];
 
@@ -27,13 +47,26 @@ function crawl() {
       resourceData,
       queueItem
     ]);
+    var unicodeResourceData = resourceData.toString("utf8");
 
-    resources.push.apply(resources, findSrcSetURLs(
-      resourceData.toString("utf8"),
-      queueItem.url
-    ));
+    URL_FINDERS.forEach(function(findURLs) {
+      resources.push.apply(resources, findURLs(
+        unicodeResourceData,
+        queueItem.url
+      ));
+    });
 
-    return resources;
+    return resources.map(function(url) {
+      // It's possible that some of our URLs might be absolute URLs
+      // based on config.ORIGIN. However, because the server we've
+      // started for crawling is based at a dynamic origin on localhost,
+      // we need to rebase such URLs to be at our dynamic origin, so
+      // that they're actually spidered.
+      if (url.indexOf(config.ORIGIN) === 0) {
+        return urlResolve(queueItem.url, url.replace(config.ORIGIN, ''));
+      }
+      return url;
+    });
   };
 
   crawler.on('complete', function() {
@@ -65,6 +98,7 @@ function crawl() {
 }
 
 exports.findSrcSetURLs = findSrcSetURLs;
+exports.findOpenGraphURLs = findOpenGraphURLs;
 
 if (!module.parent) {
   server.listen(0, crawl);

--- a/test/spider.test.js
+++ b/test/spider.test.js
@@ -33,3 +33,11 @@ describe("findSrcSetURLs", function() {
       .should.eql([]);
   });
 });
+
+describe("findOpenGraphURLs", function() {
+  it("works", function() {
+    spider
+      .findOpenGraphURLs('<meta property="og:image" content="/blah.jpg">')
+      .should.eql(['/blah.jpg']);
+  });
+});


### PR DESCRIPTION
fixes #1047.

this sets the `og:image` for all pages to the hero unit image for the homepage, so sharing on facebook now looks like this:

![2015-06-19_9-17-43](https://cloud.githubusercontent.com/assets/124687/8254158/278bb130-1664-11e5-9ba4-333adc8b99e7.jpg)

note that if you want to test this locally, you should use ngrok.com *and* set your `ORIGIN` to whatever your ngrok origin is. otherwise the [absolute URL in the `og:image`](https://github.com/mozilla/teach.webmaker.org/pull/1051#discussion_r32827149) won't be findable by facebook's [open graph debugger](https://developers.facebook.com/tools/debug/).

i also noticed that the open graph debugger is *extremely* flaky right now; i had to re-scrape my pages multiple times for it to succeed, for some reason.