### PR TITLE
Add /healthcheck page

### DIFF
--- a/components/dev-ribbon.jsx
+++ b/components/dev-ribbon.jsx
@@ -4,6 +4,7 @@ var React = require('react');
 
 var Modal = require('../components/modal.jsx');
 var ModalManagerMixin = require('../mixins/modal-manager');
+var Healthcheck = require('../pages/healthcheck.jsx');
 var TeachAPI = require('../lib/teach-api');
 var packageJSON = require('../package.json');
 
@@ -79,39 +80,6 @@ var DevModal = React.createClass({
   render: function() {
     var testURL = "/test/";
     var testName = "Test Suite";
-    var rev = document.querySelector('meta[name="git-rev"]');
-
-    if (rev) {
-      rev = rev.getAttribute('content');
-      rev = (
-        <span> based on commit <code>
-            <a target="_blank"
-               href={"https://github.com/mozilla/teach.webmaker.org/commit/" + rev}>
-              {rev.slice(0, 10)}
-            </a>
-        </code>, which is based on version <code>
-          <a target="_blank"
-             href={"https://github.com/mozilla/teach.webmaker.org/releases/tag/v" + packageJSON.version}>
-             {packageJSON.version}
-          </a>
-        </code> (potentially with <a
-          target="_blank"
-          href={"https://github.com/mozilla/teach.webmaker.org/compare/v" +
-                packageJSON.version + "..." + rev}>
-            changes
-          </a>)
-        </span>
-      );
-    } else {
-      rev = (
-        <span> based on version <code>
-          <a target="_blank"
-             href={"https://github.com/mozilla/teach.webmaker.org/releases/tag/v" + packageJSON.version}>
-             {packageJSON.version}
-          </a>
-        </code></span>
-      );
-    }
 
     if (process.env.NODE_ENV === 'production') {
       testURL = "/test/manual/";
@@ -120,8 +88,7 @@ var DevModal = React.createClass({
 
     return (
       <Modal modalTitle="Development Version">
-        <p>This is a development version of the <a href="https://github.com/mozilla/teach.webmaker.org" target="_blank">Teach Site</a>{rev}.</p>
-
+        <Healthcheck.HealthcheckMeta/>
         <a href="http://invis.io/9G2DK7SR2" target="_blank" className="btn btn-block btn-default">
           <span className="glyphicon glyphicon glyphicon-plane"/> Site Map
         </a>

--- a/less/pages/healthcheck.less
+++ b/less/pages/healthcheck.less
@@ -7,10 +7,22 @@
     width: 100%;
   }
   .site-meta {
+    font-size: 1.8rem;
     text-align: center;
     margin: 5rem auto;
     @media screen and (min-width: @screen-sm-min) {
       max-width: 50rem;
+    }
+  }
+  .go-back-home {
+    margin-top: 4rem;
+    a {
+      &:hover {
+        text-decoration: none;
+        i.fa {
+          transform: scale(1.2);
+        }
+      }
     }
   }
 }

--- a/less/pages/healthcheck.less
+++ b/less/pages/healthcheck.less
@@ -1,0 +1,9 @@
+.page.healthcheck {
+  .site-meta {
+    text-align: center;
+    margin: 5rem auto;
+    @media screen and (min-width: @screen-sm-min) {
+      max-width: 50rem;
+    }
+  }
+}

--- a/less/pages/healthcheck.less
+++ b/less/pages/healthcheck.less
@@ -1,4 +1,11 @@
 .page.healthcheck {
+  .sidebar,
+  footer {
+    display: none !important;
+  }
+  main {
+    width: 100%;
+  }
   .site-meta {
     text-align: center;
     margin: 5rem auto;

--- a/less/pages/index.less
+++ b/less/pages/index.less
@@ -1,5 +1,6 @@
 @import "activities";
 @import "home";
+@import "healthcheck";
 @import "clubs";
 @import "teach-like-mozilla";
 @import "about";

--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -40,6 +40,8 @@ var routes = (
      handler={require('../pages/tools.jsx')}/>
     <Route name="fixme" path="/fixme/"
      handler={require('../pages/fixme.jsx')}/>
+    <Route name="healthcheck" path="/healthcheck/"
+     handler={require('../pages/healthcheck.jsx')}/>
     <DefaultRoute name="home"
      handler={require('../pages/home.jsx')}/>
   </Route>

--- a/pages/healthcheck.jsx
+++ b/pages/healthcheck.jsx
@@ -4,43 +4,65 @@ var Link = Router.Link;
 var packageJSON = require('../package.json');
 var config = require('../lib/config');
 
-var HealthcheckPage = React.createClass({
-  statics: {
-    pageClassName: "healthcheck",
-    pageTitle: 'Site Health Check'
-  },
+var HealthcheckMeta = React.createClass({
   getInitialState: function() {
     return {
-      commit: ""
+      rev: ""
     }
   },
   componentDidMount: function() {
-    var rev = document.querySelector('meta[name="git-rev"]').getAttribute('content');
-    var commitDom = document.querySelector(".commit");
-    commitDom.innerHTML = rev.slice(0,10);
-    commitDom.setAttribute("href", "https://github.com/mozilla/teach.webmaker.org/commit/"+rev);
+    this.setState({ rev: document.querySelector('meta[name="git-rev"]').getAttribute('content') });
   },
   render: function() {
-    var siteType = (process.env.NODE_ENV === 'production') ? "production" : "development";
+    var version = <span>
+                    based on version
+                    <code>
+                      <a target="_blank"
+                         href={"https://github.com/mozilla/teach.webmaker.org/releases/tag/v" + packageJSON.version}>
+                        {packageJSON.version}
+                      </a>
+                    </code>
+                  </span>;
+    return (
+      <div>
+        <span>This is a {process.env.NODE_ENV || 'development'} version of the <a href="https://github.com/mozilla/teach.webmaker.org" target="_blank">Teach Site</a> </span>
+        { this.state.rev ?
+          <span>
+            based on commit
+            <code>
+              <a target="_blank" href={"https://github.com/mozilla/teach.webmaker.org/commit/"+this.state.rev} className="commit">{this.state.rev.slice(0,10)}</a>
+            </code>,
+            which is based {version} (potentially with <a
+              target="_blank"
+              href={"https://github.com/mozilla/teach.webmaker.org/compare/v" +
+                    packageJSON.version + "..." + this.state.rev}>
+                changes
+              </a>)
+          </span>
+          : <div>{version}</div>
+        }
+      </div>
+    );
+  }
+});
+
+var HealthcheckPage = React.createClass({
+  statics: {
+    pageClassName: "healthcheck",
+    pageTitle: 'Site Health Check',
+    HealthcheckMeta: HealthcheckMeta
+  },
+  render: function() {
     return (
       <div className="site-meta">
         <h1>Site Health Check</h1>
-        <p>
-          This is a {siteType} version of the <a href="https://github.com/mozilla/teach.webmaker.org" target="_blank">Teach Site</a> based on commit
-          <code>
-              <a target="_blank" href="" className="commit"> </a>
-          </code>,
-          which is based on version
-          <code>
-            <a target="_blank"
-               href={"https://github.com/mozilla/teach.webmaker.org/releases/tag/v" + packageJSON.version}>
-              {packageJSON.version}
-            </a>
-          </code>
-        </p>
-        <p>
-          <small>go back to <Link to="home">{config.ORIGIN}</Link></small>
-        </p>
+        <HealthcheckMeta/>
+        <div className="go-back-home">
+          <Link to="home">
+            <i className="fa fa-home fa-2x"></i>
+            <div><small>go back to {config.ORIGIN}</small></div>
+          </Link>
+        </div>
       </div>
     );
   }

--- a/pages/healthcheck.jsx
+++ b/pages/healthcheck.jsx
@@ -1,5 +1,8 @@
 var React = require('react');
+var Router = require('react-router');
+var Link = Router.Link;
 var packageJSON = require('../package.json');
+var config = require('../lib/config');
 
 var HealthcheckPage = React.createClass({
   statics: {
@@ -34,6 +37,9 @@ var HealthcheckPage = React.createClass({
               {packageJSON.version}
             </a>
           </code>
+        </p>
+        <p>
+          <small>go back to <Link to="home">{config.ORIGIN}</Link></small>
         </p>
       </div>
     );

--- a/pages/healthcheck.jsx
+++ b/pages/healthcheck.jsx
@@ -1,0 +1,43 @@
+var React = require('react');
+var packageJSON = require('../package.json');
+
+var HealthcheckPage = React.createClass({
+  statics: {
+    pageClassName: "healthcheck",
+    pageTitle: 'Site Health Check'
+  },
+  getInitialState: function() {
+    return {
+      commit: ""
+    }
+  },
+  componentDidMount: function() {
+    var rev = document.querySelector('meta[name="git-rev"]').getAttribute('content');
+    var commitDom = document.querySelector(".commit");
+    commitDom.innerHTML = rev.slice(0,10);
+    commitDom.setAttribute("href", "https://github.com/mozilla/teach.webmaker.org/commit/"+rev);
+  },
+  render: function() {
+    var siteType = (process.env.NODE_ENV === 'production') ? "production" : "development";
+    return (
+      <div className="site-meta">
+        <h1>Site Health Check</h1>
+        <p>
+          This is a {siteType} version of the <a href="https://github.com/mozilla/teach.webmaker.org" target="_blank">Teach Site</a> based on commit
+          <code>
+              <a target="_blank" href="" className="commit"> </a>
+          </code>,
+          which is based on version
+          <code>
+            <a target="_blank"
+               href={"https://github.com/mozilla/teach.webmaker.org/releases/tag/v" + packageJSON.version}>
+              {packageJSON.version}
+            </a>
+          </code>
+        </p>
+      </div>
+    );
+  }
+});
+
+module.exports = HealthcheckPage;


### PR DESCRIPTION
This fixes #884 and is basically a simplified version of the dev ribbon modal.

### Option 1 ###
![site-health-check](https://cloud.githubusercontent.com/assets/2896608/8505685/179b7c74-21a4-11e5-9ff0-e2290f1920e2.png)

### Option 2 ###
![site-health-check-2](https://cloud.githubusercontent.com/assets/2896608/8505804/919f3f58-21a7-11e5-8eeb-25a8770b58ad.png)

@toolness any feedback or suggestion? I prefer option #2 since it's way more obvious for visitors to distinguish this page from the rest of the site(the real content).