### PR TITLE
A few grammar and CSS tweaks to /healthcheck

### DIFF
--- a/less/pages/healthcheck.less
+++ b/less/pages/healthcheck.less
@@ -16,6 +16,9 @@
   }
   .go-back-home {
     margin-top: 4rem;
+    a i.fa {
+      transition: transform 0.25s;
+    }
     a {
       &:hover {
         text-decoration: none;

--- a/pages/healthcheck.jsx
+++ b/pages/healthcheck.jsx
@@ -15,7 +15,7 @@ var HealthcheckMeta = React.createClass({
   },
   render: function() {
     var version = <span>
-                    based on version
+                    based on version&nbsp;
                     <code>
                       <a target="_blank"
                          href={"https://github.com/mozilla/teach.webmaker.org/releases/tag/v" + packageJSON.version}>
@@ -28,18 +28,18 @@ var HealthcheckMeta = React.createClass({
         <span>This is a {process.env.NODE_ENV || 'development'} version of the <a href="https://github.com/mozilla/teach.webmaker.org" target="_blank">Teach Site</a> </span>
         { this.state.rev ?
           <span>
-            based on commit
+            based on commit&nbsp;
             <code>
               <a target="_blank" href={"https://github.com/mozilla/teach.webmaker.org/commit/"+this.state.rev} className="commit">{this.state.rev.slice(0,10)}</a>
             </code>,
-            which is based {version} (potentially with <a
+            which is {version} (potentially with <a
               target="_blank"
               href={"https://github.com/mozilla/teach.webmaker.org/compare/v" +
                     packageJSON.version + "..." + this.state.rev}>
                 changes
-              </a>)
+              </a>).
           </span>
-          : <div>{version}</div>
+          : <div>{version}.</div>
         }
       </div>
     );
@@ -60,7 +60,7 @@ var HealthcheckPage = React.createClass({
         <div className="go-back-home">
           <Link to="home">
             <i className="fa fa-home fa-2x"></i>
-            <div><small>go back to {config.ORIGIN}</small></div>
+            <div><small>Go back to {config.ORIGIN}</small></div>
           </Link>
         </div>
       </div>

--- a/pages/healthcheck.jsx
+++ b/pages/healthcheck.jsx
@@ -15,7 +15,7 @@ var HealthcheckMeta = React.createClass({
   },
   render: function() {
     var version = <span>
-                    based on version&nbsp;
+                    based on version{' '}
                     <code>
                       <a target="_blank"
                          href={"https://github.com/mozilla/teach.webmaker.org/releases/tag/v" + packageJSON.version}>
@@ -28,7 +28,7 @@ var HealthcheckMeta = React.createClass({
         <span>This is a {process.env.NODE_ENV || 'development'} version of the <a href="https://github.com/mozilla/teach.webmaker.org" target="_blank">Teach Site</a> </span>
         { this.state.rev ?
           <span>
-            based on commit&nbsp;
+            based on commit{' '}
             <code>
               <a target="_blank" href={"https://github.com/mozilla/teach.webmaker.org/commit/"+this.state.rev} className="commit">{this.state.rev.slice(0,10)}</a>
             </code>,


### PR DESCRIPTION
Just a few minor changes:

* JSX can be a bit annoying with newlines because it doesn't currently [treat newlines as whitespace text](https://github.com/facebook/jsx/issues/19) like HTML does. Because it also [trims the trailing whitespace at the end of lines](https://facebook.github.io/react/blog/2014/02/20/react-v0.9.html#jsx-whitespace) we need to wrap any such whitespace in `{' '}`, which is weird, but whatever. I did this so that there's now a space between "commit" and the commit hash, and between "version" and the version number.
* I added a CSS transition to the home icon, neato.
* The word "based" was repeated twice in a row.
* The sentence didn't have a period at the end of it.
